### PR TITLE
중간지점 찾기 알고리즘 구현 #26

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/common/exception/errorCode/UserErrorCode.java
+++ b/backend/src/main/java/middle_point_search/backend/common/exception/errorCode/UserErrorCode.java
@@ -17,6 +17,7 @@ public enum UserErrorCode implements ErrorCode {
 	MEMBER_CREDENTIAL_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
 	API_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "API 인증 정보가 정확하지 않습니다."),
 	ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 방입니다."),
+	PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "방에 입력된 장소가 없습니다."),
 	//5xx
 	API_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "API 서버에 문제가 발생하였습니다.")
 

--- a/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
@@ -1,5 +1,7 @@
 package middle_point_search.backend.domains.market.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -47,13 +49,19 @@ public class Market {
 	public static Market from(MarketApiData marketApiData) {
 		System.out.println(marketApiData);
 
-		String name = marketApiData.getName();
+		String name = parseName(marketApiData.getName());
 		String siGunGu = marketApiData.getSiGunGu();
 		String siDo = marketApiData.getSiDo();
 		Double addressLatitude = parseCoordinatesToLatitude(marketApiData.getCoordinates());
 		Double addressLongitude = parseCoordinatesToLongitude(marketApiData.getCoordinates());
 
 		return new Market(name, siGunGu, siDo, addressLatitude, addressLongitude);
+	}
+
+	private static String parseName(String name) {
+		String[] s = name.split("_");
+
+		return s[0];
 	}
 
 	private static Double parseCoordinatesToLatitude(String coordinates) {
@@ -68,5 +76,18 @@ public class Market {
 		String[] coordinateParts = coordinate.split(",");
 
 		return Double.parseDouble(coordinateParts[0]);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Market market = (Market) o;
+		return Objects.equals(name, market.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
 	}
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
@@ -44,10 +44,6 @@ public class Market {
 		this.addressLongitude = addressLongitude;
 	}
 
-	// public static Market of() {
-	//
-	// }
-	//
 	public static Market from(MarketApiData marketApiData) {
 		System.out.println(marketApiData);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/market/service/MarketService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/service/MarketService.java
@@ -52,7 +52,10 @@ public class MarketService {
 			Mono<MarketApiResponse> response = webClientUtil.getMono(url, MarketApiResponse.class);
 
 			response.map(MarketApiResponse::getData)
-				.map(marketApiDatas -> marketApiDatas.stream().map(Market::from).toList())
+				.map(marketApiDatas -> marketApiDatas.stream()
+					.map(Market::from)
+					.distinct()
+					.toList())
 				.subscribe(this::saveAllMarket);
 		}
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
@@ -1,0 +1,43 @@
+package middle_point_search.backend.domains.midPoint.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import middle_point_search.backend.common.dto.DataResponse;
+import middle_point_search.backend.common.util.MemberLoader;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.MidPointsBySelfFindRequest;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.MidPointsFindResponse;
+import middle_point_search.backend.domains.midPoint.service.MidPointService;
+
+@RestController
+@RequestMapping("/api/mid-points")
+@RequiredArgsConstructor
+public class MidPointController {
+
+	private final MemberLoader memberLoader;
+	private final MidPointService midPointService;
+
+	@PostMapping("/self")
+	public ResponseEntity<DataResponse<List<MidPointsFindResponse>>> MidPointsBySelfFind(
+		@RequestBody MidPointsBySelfFindRequest request) {
+		List<MidPointsFindResponse> midPoints = midPointService.findMidPoints(request.getAddresses());
+
+		return ResponseEntity.ok(DataResponse.from(midPoints));
+	}
+
+	@GetMapping
+	public ResponseEntity<DataResponse<List<MidPointsFindResponse>>> MidPointsFind() {
+		String roomId = memberLoader.getRoomId();
+
+		List<MidPointsFindResponse> midPoints = midPointService.findMidPointsByRoomId(roomId);
+
+		return ResponseEntity.ok(DataResponse.from(midPoints));
+	}
+}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/dto/MidPointDTO.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/dto/MidPointDTO.java
@@ -1,0 +1,67 @@
+package middle_point_search.backend.domains.midPoint.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import middle_point_search.backend.domains.member.domain.Transport;
+import middle_point_search.backend.domains.place.domain.Place;
+
+public class MidPointDTO {
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class MidPointsBySelfFindRequest {
+		List<AddressDTO> addresses;
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class AddressDTO {
+
+		private String siDo;
+		private String siGunGu;
+		private String roadNameAddress;
+		private Double addressLat;
+		private Double addressLong;
+		private Transport transport;
+
+		public static AddressDTO from(Place place) {
+			return new AddressDTO(
+				place.getSiDo(),
+				place.getSiGunGu(),
+				place.getRoadNameAddress(),
+				place.getAddressLatitude(),
+				place.getAddressLongitude(),
+				place.getTransport()
+			);
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor(access = AccessLevel.PUBLIC)
+	public static class CoordinateDTO {
+
+		private Double x;
+		private Double y;
+
+		// 두 점 사이의 거리 제곱을 리턴하는 함수
+		public Double calcDist(CoordinateDTO b) {
+			return Math.pow(this.y - b.getY(), 2D) + Math.pow(this.x - b.getX(), 2D);
+		}
+	}
+
+	@AllArgsConstructor(access = AccessLevel.PUBLIC)
+	public static class MidPointsFindResponse {
+
+		private String name;
+		private String siDo;
+		private String siGunGu;
+		private String roadNameAddress;
+		private Double addressLat;
+		private Double addressLong;
+	}
+}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/dto/MidPointDTO.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/dto/MidPointDTO.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import middle_point_search.backend.domains.market.domain.Market;
 import middle_point_search.backend.domains.member.domain.Transport;
 import middle_point_search.backend.domains.place.domain.Place;
 
@@ -39,6 +40,7 @@ public class MidPointDTO {
 				place.getTransport()
 			);
 		}
+
 	}
 
 	@Getter
@@ -54,6 +56,7 @@ public class MidPointDTO {
 		}
 	}
 
+	@Getter
 	@AllArgsConstructor(access = AccessLevel.PUBLIC)
 	public static class MidPointsFindResponse {
 
@@ -63,5 +66,16 @@ public class MidPointDTO {
 		private String roadNameAddress;
 		private Double addressLat;
 		private Double addressLong;
+
+		public static MidPointsFindResponse from(Market market) {
+			return new MidPointsFindResponse(
+				market.getName(),
+				market.getSiDo(),
+				market.getSiGunGu(),
+				null,
+				market.getAddressLatitude(),
+				market.getAddressLongitude()
+			);
+		}
 	}
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/service/MidPointService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/service/MidPointService.java
@@ -1,0 +1,37 @@
+package middle_point_search.backend.domains.midPoint.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.AddressDTO;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.MidPointsFindResponse;
+import middle_point_search.backend.domains.midPoint.util.MidPointUtil;
+import middle_point_search.backend.domains.place.domain.Place;
+import middle_point_search.backend.domains.place.repository.PlaceRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MidPointService {
+
+	private final MidPointUtil midPointUtil;
+	private final PlaceRepository placeRepository;
+
+	// 주어진 주소들로 중간 장소 리스트를 조회하는 메서드
+	public List<MidPointsFindResponse> findMidPoints(List<AddressDTO> addressDTOs) {
+		return midPointUtil.findMidPoints(addressDTOs);
+	}
+
+	// 주어진 RoomId로 중간 장소 리스트를 조회하는 메서드
+	public List<MidPointsFindResponse> findMidPointsByRoomId(String roomId) {
+		List<Place> places = placeRepository.findAllByRoom_IdentityNumber(roomId);
+		List<AddressDTO> addressDTOs = places.stream()
+			.map(AddressDTO::from)
+			.toList();
+
+		return findMidPoints(addressDTOs);
+	}
+}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtil.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtil.java
@@ -2,11 +2,10 @@ package middle_point_search.backend.domains.midPoint.util;
 
 import java.util.List;
 
-import middle_point_search.backend.domains.midPoint.dto.MidPointDTO;
 import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.AddressDTO;
-import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.CoordinateDTO;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.MidPointsFindResponse;
 
 public interface MidPointUtil {
 
-	List<AddressDTO> findMidPoints(List<AddressDTO> addresses);
+	List<MidPointsFindResponse> findMidPoints(List<AddressDTO> addresses);
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtil.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtil.java
@@ -1,0 +1,12 @@
+package middle_point_search.backend.domains.midPoint.util;
+
+import java.util.List;
+
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.AddressDTO;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.CoordinateDTO;
+
+public interface MidPointUtil {
+
+	List<AddressDTO> findMidPoints(List<AddressDTO> addresses);
+}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
@@ -21,6 +21,7 @@ import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.MidPointsFin
 public class MidPointUtilV1 implements MidPointUtil {
 
 	private final MarketRepository marketRepository;
+	private final int NUMBER_OF_RESULT = 5;
 
 	@Override
 	public List<MidPointsFindResponse> findMidPoints(List<AddressDTO> addresses) {
@@ -38,26 +39,26 @@ public class MidPointUtilV1 implements MidPointUtil {
 		double midX = mid.getX();
 		double midY = mid.getY();
 
-		List<Market> all = marketRepository.findAll();
+		List<Market> markets = marketRepository.findAll();
 
-		Market nearMarket = null;
-		double distMin = Double.MAX_VALUE;
+		markets.sort((o1, o2) -> {
+			double x1 = o1.getAddressLongitude();
+			double y1 = o1.getAddressLatitude();
+			double x2 = o2.getAddressLongitude();
+			double y2 = o2.getAddressLatitude();
 
-		for (Market market : all) {
-			double x = market.getAddressLongitude();
-			double y = market.getAddressLatitude();
+			double dist1 = calcDist(midX, midY, x1, y1);
+			double dist2 = calcDist(midX, midY, x2, y2);
 
-			double dist = calcDist(x, y, midX, midY);
-			if (dist < distMin) {
-				distMin = dist;
-				nearMarket = market;
-			}
-		}
-
-		MidPointsFindResponse response = MidPointsFindResponse.from(nearMarket);
+			return (int)(dist1 - dist2);
+		});
 
 		List<MidPointsFindResponse> responses = new ArrayList<>();
-		responses.add(response);
+
+		for (int i = 0; i < NUMBER_OF_RESULT; i++) {
+			responses.add(MidPointsFindResponse.from(markets.get(i)));
+		}
+
 		return responses;
 	}
 

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
@@ -1,0 +1,120 @@
+package middle_point_search.backend.domains.midPoint.util;
+
+import java.util.List;
+import java.util.Stack;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.AddressDTO;
+import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.CoordinateDTO;
+
+@Slf4j
+@Component
+public class MidPointUtilV1 implements MidPointUtil {
+
+	@Override
+	public List<AddressDTO> findMidPoints(List<AddressDTO> addresses) {
+		List<CoordinateDTO> coordinates = addresses.stream()
+			.map(address -> new CoordinateDTO(address.getAddressLong(), address.getAddressLat()))
+			.collect(Collectors.toList());
+
+		CoordinateDTO coordinate = calcMidPointCoordinate(coordinates);
+
+		return null;
+	}
+
+	private CoordinateDTO calcMidPointCoordinate(List<CoordinateDTO> coordinates) {
+		// 정렬의 기준이 될 좌표
+		CoordinateDTO standard = findStandardPoint(coordinates);
+
+		// 좌표 정렬
+		coordinates.sort((o1, o2) -> {
+			int ccwR = ccw(standard, o1, o2);
+
+			if (ccwR > 0) { //반시계방향
+				return -1;
+			} else if (ccwR < 0) { //시계방향
+				return 1;
+			} else { //거리가 더 가까운 것을 앞 쪽으로
+				double dist1 = standard.calcDist(o1);
+				double dist2 = standard.calcDist(o2);
+				if (dist1 > dist2) {
+					return 1;
+				} else {
+					return -1;
+				}
+			}
+		});
+
+		List<CoordinateDTO> borderCoordinates = grahamScan(coordinates, standard);
+
+		for (CoordinateDTO c : borderCoordinates) {
+			log.info("x : {}, y : {}", c.getX(), c.getY());
+		}
+
+		return null;
+	}
+
+	private List<AddressDTO> findMidPointsByCoordinate(CoordinateDTO coordinateDTO) {
+		return null;
+	}
+
+	// 두 벡터의 외적을 통해 시계, 반시계 방향을 구하는 ccw 알고리즘
+	// CA X AB 이다.
+	// ccw => 1: 반시계, 0: 일직선, -1: 시계
+	private int ccw(CoordinateDTO a, CoordinateDTO b, CoordinateDTO c) {
+		double ccwR = (b.getX() - a.getX()) * (c.getY() - a.getX()) - (c.getX() - a.getX()) * (b.getY() - a.getY());
+
+		if (ccwR > 0) {
+			return 1;
+		} else if (ccwR < 0) {
+			return -1;
+		} else {
+			return 0;
+		}
+	}
+
+	// 그라함 스캔 알고리즘, 테두리 좌표들만 구하기
+	private List<CoordinateDTO> grahamScan(List<CoordinateDTO> coordinateDTOs, CoordinateDTO standard) {
+		Stack<CoordinateDTO> S = new Stack<>();
+		S.add(standard);
+
+		for (int i = 1; i < coordinateDTOs.size(); i++) {
+			//시계 방향이면 제거 한다.
+			while (S.size() > 1 && ccw(S.get(S.size() - 2), S.get(S.size() - 1), coordinateDTOs.get(i)) <= 0) {
+				S.pop();
+			}
+			S.add(coordinateDTOs.get(i));
+		}
+
+		return S.stream().toList();
+	}
+
+
+	// 기준 좌표 구하기
+	private CoordinateDTO findStandardPoint(List<CoordinateDTO> coordinateDTOs) {
+		CoordinateDTO first = coordinateDTOs.get(0);
+		double firstX = first.getX();
+		double firstY = first.getY();
+
+		for (int i = 1; i < coordinateDTOs.size(); i++) {
+			CoordinateDTO coordinateDTO = coordinateDTOs.get(i);
+			double x = coordinateDTO.getX();
+			double y = coordinateDTO.getY();
+
+			// y 좌표가 가장 작은 좌표를 찾는다.
+			// y가 같은 경우 x가 더 작은 것을 선택한다.
+			if (y < firstY) {
+				first = coordinateDTO;
+			} else if (y == firstY){
+				if (x < firstX) {
+					first = coordinateDTO;
+				}
+			}
+		}
+
+		return first;
+	}
+}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
@@ -1,5 +1,7 @@
 package middle_point_search.backend.domains.midPoint.util;
 
+import static middle_point_search.backend.common.exception.errorCode.UserErrorCode.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -9,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import middle_point_search.backend.common.exception.CustomException;
 import middle_point_search.backend.domains.market.domain.Market;
 import middle_point_search.backend.domains.market.repository.MarketRepository;
 import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.AddressDTO;
@@ -25,6 +28,11 @@ public class MidPointUtilV1 implements MidPointUtil {
 
 	@Override
 	public List<MidPointsFindResponse> findMidPoints(List<AddressDTO> addresses) {
+		// address가 없을 경우
+		if (addresses.isEmpty()) {
+			throw new CustomException(PLACE_NOT_FOUND);
+		}
+
 		List<CoordinateDTO> coordinates = addresses.stream()
 			.map(address -> new CoordinateDTO(address.getAddressLong(), address.getAddressLat()))
 			.collect(Collectors.toList());

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
@@ -34,7 +34,9 @@ public class MidPointUtilV1 implements MidPointUtil {
 		}
 
 		List<CoordinateDTO> coordinates = addresses.stream()
-			.map(address -> new CoordinateDTO(address.getAddressLong(), address.getAddressLat()))
+			.map(address -> {
+				return new CoordinateDTO(address.getAddressLong(), address.getAddressLat());
+			})
 			.collect(Collectors.toList());
 
 		CoordinateDTO coordinate = calcMidPointCoordinate(coordinates);
@@ -58,7 +60,13 @@ public class MidPointUtilV1 implements MidPointUtil {
 			double dist1 = calcDist(midX, midY, x1, y1);
 			double dist2 = calcDist(midX, midY, x2, y2);
 
-			return (int)(dist1 - dist2);
+			if (dist1 > dist2) {
+				return 1;
+			} else if (dist1 == dist2) {
+				return 0;
+			} else {
+				return -1;
+			}
 		});
 
 		List<MidPointsFindResponse> responses = new ArrayList<>();
@@ -167,6 +175,6 @@ public class MidPointUtilV1 implements MidPointUtil {
 
 	// 두 점 사이의 거리 제곱을 리턴하는 함수
 	public Double calcDist(double x1, double y1, double x2, double y2) {
-		return Math.pow(y2 - y1, 2D) + Math.pow(x2 - x1, 2D);
+		return Math.pow(y2 - y1, 2) + Math.pow(x2 - x1, 2);
 	}
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/util/MidPointUtilV1.java
@@ -22,10 +22,48 @@ public class MidPointUtilV1 implements MidPointUtil {
 
 		CoordinateDTO coordinate = calcMidPointCoordinate(coordinates);
 
+		return findMidPointsByCoordinate(coordinate);
+	}
+
+	// 주어진 중간 위치 좌표를 통해 추천 장소를 구하는 메서드
+	private List<AddressDTO> findMidPointsByCoordinate(CoordinateDTO coordinateDTO) {
 		return null;
 	}
 
+	// 여러 좌표의 무게 중심 구하는 메서드
 	private CoordinateDTO calcMidPointCoordinate(List<CoordinateDTO> coordinates) {
+
+		List<CoordinateDTO> borderCoordinates = grahamScan(coordinates);
+
+		double count = borderCoordinates.size();
+		double sumX = 0;
+		double sumY = 0;
+
+		for (CoordinateDTO coordinate : borderCoordinates) {
+			sumX += coordinate.getX();
+			sumY += coordinate.getY();
+		}
+
+		return new CoordinateDTO(sumX / count, sumY / count);
+	}
+
+	// 두 벡터의 외적을 통해 시계, 반시계 방향을 구하는 ccw 알고리즘
+	// CA X AB 이다.
+	// ccw => 1: 반시계, 0: 일직선, -1: 시계
+	private int ccw(CoordinateDTO a, CoordinateDTO b, CoordinateDTO c) {
+		double ccwR = (b.getX() - a.getX()) * (c.getY() - a.getX()) - (c.getX() - a.getX()) * (b.getY() - a.getY());
+
+		if (ccwR > 0) {
+			return 1;
+		} else if (ccwR < 0) {
+			return -1;
+		} else {
+			return 0;
+		}
+	}
+
+	// 그라함 스캔 알고리즘, 테두리 좌표들만 구하기
+	private List<CoordinateDTO> grahamScan(List<CoordinateDTO> coordinates) {
 		// 정렬의 기준이 될 좌표
 		CoordinateDTO standard = findStandardPoint(coordinates);
 
@@ -48,45 +86,15 @@ public class MidPointUtilV1 implements MidPointUtil {
 			}
 		});
 
-		List<CoordinateDTO> borderCoordinates = grahamScan(coordinates, standard);
-
-		for (CoordinateDTO c : borderCoordinates) {
-			log.info("x : {}, y : {}", c.getX(), c.getY());
-		}
-
-		return null;
-	}
-
-	private List<AddressDTO> findMidPointsByCoordinate(CoordinateDTO coordinateDTO) {
-		return null;
-	}
-
-	// 두 벡터의 외적을 통해 시계, 반시계 방향을 구하는 ccw 알고리즘
-	// CA X AB 이다.
-	// ccw => 1: 반시계, 0: 일직선, -1: 시계
-	private int ccw(CoordinateDTO a, CoordinateDTO b, CoordinateDTO c) {
-		double ccwR = (b.getX() - a.getX()) * (c.getY() - a.getX()) - (c.getX() - a.getX()) * (b.getY() - a.getY());
-
-		if (ccwR > 0) {
-			return 1;
-		} else if (ccwR < 0) {
-			return -1;
-		} else {
-			return 0;
-		}
-	}
-
-	// 그라함 스캔 알고리즘, 테두리 좌표들만 구하기
-	private List<CoordinateDTO> grahamScan(List<CoordinateDTO> coordinateDTOs, CoordinateDTO standard) {
 		Stack<CoordinateDTO> S = new Stack<>();
 		S.add(standard);
 
-		for (int i = 1; i < coordinateDTOs.size(); i++) {
+		for (int i = 1; i < coordinates.size(); i++) {
 			//시계 방향이면 제거 한다.
-			while (S.size() > 1 && ccw(S.get(S.size() - 2), S.get(S.size() - 1), coordinateDTOs.get(i)) <= 0) {
+			while (S.size() > 1 && ccw(S.get(S.size() - 2), S.get(S.size() - 1), coordinates.get(i)) <= 0) {
 				S.pop();
 			}
-			S.add(coordinateDTOs.get(i));
+			S.add(coordinates.get(i));
 		}
 
 		return S.stream().toList();


### PR DESCRIPTION
## 개요
- close #26 

## 작업사항
- 중간지점 찾기 알고리즘 구현
- 중간지점 찾기 API 구현


## 아쉬운점
### 중간지점을 교통 중심이 아니라, 위치 중심으로 찾고 있다.
추후 카카오 API를 이용하여 교통 시간 기준 중간 지점 알고리즘 찾기를 구현해봐야겠다. 

### 중간지점  좌표를 이용해 근처 상권을 찾을 때 모든 상권을 정렬하여 데이터를 가져온다.
가까운 5개를 찾을 때 클러스터링화된 데이터를 기준으로 찾으면 훨 성능이 좋아질 거 같다.

