### PR TITLE
Refactor: Maket 정보 업데이트 기능 성능 최적화

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/common/webClient/util/WebClientUtil.java
+++ b/backend/src/main/java/middle_point_search/backend/common/webClient/util/WebClientUtil.java
@@ -49,6 +49,23 @@ public class WebClientUtil {
 	}
 
 	// WebClient Conf 세팅을 이용하며, url과 응답 클래스 및 파라미터를 제공하여 요청을 해 Mono로 응답받는 메서드
+	public <T> Mono<T> getMarketByMono(String url, MultiValueMap<String, String> params, Class<T> response) {
+		return webClientForMarket
+			.method(HttpMethod.GET)
+			.uri(uriBuilder -> uriBuilder
+				.path(url)
+				.queryParam(marketProperties.getParamKey(), marketProperties.getKey())
+				.queryParams(params)
+				.build())
+			.retrieve()
+			.onStatus(HttpStatusCode::is4xxClientError,
+				clientResponse -> Mono.error(new CustomException(BAD_REQUEST)))
+			.onStatus(HttpStatusCode::is5xxServerError,
+				clientResponse -> Mono.error(new CustomException(API_INTERNAL_SERVER_ERROR)))
+			.bodyToMono(response);
+	}
+
+	// WebClient Conf 세팅을 이용하며, url과 응답 클래스 및 파라미터를 제공하여 요청을 해 Mono로 응답받는 메서드
 	public <T> T getKakao(String url, MultiValueMap<String, String> params, Class<T> response) {
 		return webClientForKakao
 			.method(HttpMethod.GET)

--- a/backend/src/main/java/middle_point_search/backend/domains/market/controller/MarketController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/controller/MarketController.java
@@ -28,11 +28,12 @@ public class MarketController {
 	@Operation(
 		summary = "중간 장소 리스트 업데이트",
 		parameters = {
-			@Parameter(name = "RoomId", description = "roomId 필요", required = true, in = ParameterIn.HEADER)
+			@Parameter(name = "RoomId", description = "roomId 필요", in = ParameterIn.HEADER),
+			@Parameter(name = "RoomType", description = "roomType 필요. [TOGETHER, SELF] 중 하나", in = ParameterIn.HEADER)
 		},
 		description = """
 			중간 지점으로 선정될 장소를 업데이트 한다.
-						
+			
 			AccessToken 필요(ADMIN 권한 필요.)"""
 	)
 	public ResponseEntity<BaseResponse> marketUpdate() {

--- a/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
@@ -47,8 +47,6 @@ public class Market {
 	}
 
 	public static Market from(MarketApiData marketApiData) {
-		System.out.println(marketApiData);
-
 		String name = parseName(marketApiData.getName());
 		String siGunGu = marketApiData.getSiGunGu();
 		String siDo = marketApiData.getSiDo();

--- a/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
@@ -18,7 +18,7 @@ import middle_point_search.backend.domains.market.dto.response.MarketApiData;
 public class Market {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.SEQUENCE)
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "market_id")
 	private Long id;
 

--- a/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/domain/Market.java
@@ -18,7 +18,7 @@ import middle_point_search.backend.domains.market.dto.response.MarketApiData;
 public class Market {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@GeneratedValue(strategy = GenerationType.SEQUENCE)
 	@Column(name = "market_id")
 	private Long id;
 

--- a/backend/src/main/java/middle_point_search/backend/domains/market/repository/MarketQueryRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/repository/MarketQueryRepository.java
@@ -1,0 +1,35 @@
+package middle_point_search.backend.domains.market.repository;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import middle_point_search.backend.domains.market.domain.Market;
+
+@Repository
+@RequiredArgsConstructor
+public class MarketQueryRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Transactional
+	public void saveAll(List<Market> markets) {
+		String sql = "INSERT INTO market (name, si_gun_gu, si_do, address_latitude, address_longitude) " +
+			"VALUES (?, ?, ?, ?, ?)";
+
+		jdbcTemplate.batchUpdate(sql,
+			markets,
+			markets.size(),
+			(PreparedStatement ps, Market market) -> {
+				ps.setString(1, market.getName());
+				ps.setString(2, market.getSiGunGu());
+				ps.setString(3, market.getSiDo());
+				ps.setDouble(4, market.getAddressLatitude());
+				ps.setDouble(5, market.getAddressLongitude());
+			});
+	}
+}

--- a/backend/src/main/java/middle_point_search/backend/domains/market/repository/MarketRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/repository/MarketRepository.java
@@ -1,8 +1,14 @@
 package middle_point_search.backend.domains.market.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import middle_point_search.backend.domains.market.domain.Market;
 
 public interface MarketRepository extends JpaRepository<Market, Long> {
+
+	@Modifying
+	@Query(value = "DELETE FROM Market")
+	void deleteAllMarket();
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/market/service/MarketService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/service/MarketService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import middle_point_search.backend.common.exception.CustomException;
 import middle_point_search.backend.common.exception.errorCode.CommonErrorCode;
-import middle_point_search.backend.common.properties.KakaoProperties;
 import middle_point_search.backend.common.properties.MarketProperties;
 import middle_point_search.backend.common.webClient.util.WebClientUtil;
 import middle_point_search.backend.domains.market.domain.Market;
@@ -28,20 +27,15 @@ public class MarketService {
 	private final MarketRepository marketRepository;
 
 	private final MarketProperties marketProperties;
-	private final KakaoProperties kakaoProperties;
 
 	private final WebClientUtil webClientUtil;
 
 	// Market 정보 업데이트하기
 	@Transactional(rollbackFor = {CustomException.class})
 	public void updateMarket() {
-
-		log.info("{}", marketProperties.getBaseUrl());
-		marketRepository.deleteAll();
+		marketRepository.deleteAllMarket();
 
 		int marketCount = getMarketCount();
-
-		log.info("{}", marketCount);
 		int totalPage = parseCountToPage(marketCount);
 
 		requestAndSaveMarkets(totalPage);
@@ -49,6 +43,7 @@ public class MarketService {
 
 	// Market 총 데이터 수 가져오기
 	private int getMarketCount() {
+		long startTime = System.currentTimeMillis();
 		String url = marketProperties.getMarketApiUrl();
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -61,11 +56,14 @@ public class MarketService {
 			throw new CustomException(CommonErrorCode.EXTERNAL_SERVER_ERROR);
 		}
 
+		long stopTime = System.currentTimeMillis();
+		log.info("getMarketCount | time = {}ms", stopTime - startTime);
 		return response.getTotalCount();
 	}
 
 	// market api를 요청하고 가져온 데이터를 저장하는 메서드
 	private void requestAndSaveMarkets(int totalPage) {
+		long startTime = System.currentTimeMillis();
 		for (int i = 1; i <= totalPage; i++) {
 			String url = marketProperties.getMarketApiUrl();
 
@@ -79,14 +77,13 @@ public class MarketService {
 				throw new CustomException(CommonErrorCode.EXTERNAL_SERVER_ERROR);
 			}
 
-			List<Market> markets = response.getData()
-				.stream()
-				.map(Market::from)
-				.distinct()
-				.toList();
+			List<Market> markets = response.getData().stream().map(Market::from).distinct().toList();
 
 			saveAllMarket(markets);
 		}
+
+		long stopTime = System.currentTimeMillis();
+		log.info("requestAndSaveMarkets | time = {}ms", stopTime - startTime);
 	}
 
 	// 데이터 개수를 페이지로 변환해주는 메서드(개수가 2001이면 1,2,3 페이지로 3 페이지가 리턴)
@@ -100,6 +97,9 @@ public class MarketService {
 
 	// Market List 저장
 	private void saveAllMarket(List<Market> markets) {
+		long startTime = System.currentTimeMillis();
 		marketRepository.saveAll(markets);
+		long stopTime = System.currentTimeMillis();
+		log.info("saveAllMarket | time = {}ms", stopTime - startTime);
 	}
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/market/service/MarketService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/market/service/MarketService.java
@@ -16,6 +16,7 @@ import middle_point_search.backend.common.properties.MarketProperties;
 import middle_point_search.backend.common.webClient.util.WebClientUtil;
 import middle_point_search.backend.domains.market.domain.Market;
 import middle_point_search.backend.domains.market.dto.response.MarketApiResponse;
+import middle_point_search.backend.domains.market.repository.MarketQueryRepository;
 import middle_point_search.backend.domains.market.repository.MarketRepository;
 
 @Slf4j
@@ -24,6 +25,7 @@ import middle_point_search.backend.domains.market.repository.MarketRepository;
 @RequiredArgsConstructor
 public class MarketService {
 
+	private final MarketQueryRepository marketQueryRepository;
 	private final MarketRepository marketRepository;
 
 	private final MarketProperties marketProperties;
@@ -98,7 +100,7 @@ public class MarketService {
 	// Market List 저장
 	private void saveAllMarket(List<Market> markets) {
 		long startTime = System.currentTimeMillis();
-		marketRepository.saveAll(markets);
+		marketQueryRepository.saveAll(markets);
 		long stopTime = System.currentTimeMillis();
 		log.info("saveAllMarket | time = {}ms", stopTime - startTime);
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
@@ -35,7 +35,7 @@ public class MidPointController {
 		summary = "중간 지점 추천 장소 조회",
 		description = """
 			중간 지점 추천 장소 조회하기.
-						
+			
 			AccessToken 필요.""",
 		parameters = {
 			@Parameter(name = "RoomId", description = "roomId 필요", in = ParameterIn.HEADER),

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,10 +7,15 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.highlight_sql=true
-logging.level.org.hibernate.orm.jdbc.bind = trace
+logging.level.org.hibernate.orm.jdbc.bind = false
 
 spring.devtools.livereload.enabled=true
 spring.devtools.restart.enabled=true
+
+#batch
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
 
 #swagger
 springdoc.swagger-ui.path=/swagger-ui.html
@@ -18,7 +23,6 @@ springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.tags-sorter=alpha
 springdoc.swagger-ui.operations-sorter=alpha
 springdoc.api-docs.path=/api-docs
-
 
 springdoc.default-consumes-media-type=application/json;charset=UTF-8
 springdoc.default-produces-media-type=application/json;charset=UTF-8


### PR DESCRIPTION
## 개요
- close #138 

# 구현 의도
Market 업데이트 기능의 경우 총 업데이트 하는 데 2초 이상이 걸렸었다.
이는 그 2초동안 DB에 락을 걸고 있기에, 그 사이의 요청은 장애가 날 수 있었다.
# 구현 사항
## deleteAll() 메서드를 네이티브 쿼리로 변경
deleteAll() 메서드를 어림짐작으로 하나의 쿼리를 통해 모든 데이터를 삭제하지 않을까 생각했었습니다.
그러나 막상 로직을 까보니
![image](https://github.com/user-attachments/assets/fbfd218a-e037-4e04-af37-952f81c023f5)

위와 같이 모든 엔티티를 하나씩 삭제하는 것을 알게 되었습니다.

이를 해결하기 위해 JPQL을 통해 직접 쿼리문을 작성했습니다.
```
public interface MarketRepository extends JpaRepository<Market, Long> {

	@Modifying
	@Query(value = "DELETE FROM Market")
	void deleteAllMarket();
}
```
이를 통해 수천번 나가던 쿼리문이 하나의 쿼리문으로 줄어들었고 대략 0.5초 정도의 성능을 개선할 수 있었습니다.

## Bulk Insert를 통한 저장 로직 최적화
```
	// Market List 저장
	private void saveAllMarket(List<Market> markets) {
		marketRepository.saveAll(markets);
	}
```
기존에는 위와 같이 saveAll() 메서드를 통해 정보를 저장했습니다.
다만 saveAll() 로직 자체가 내부적으로 객체 하나당 Insert문을 호출하는 방식이었기 때문에, 쓰기지연은 됐으나 쿼리문은 엄청 많이 나갔습니다.

이 Insert문을 하나의 쿼리로 만들고 싶었고, 이를 위해 Bulk Insert를 사용하게 되었습니다.
이를 위해 application.properties에 jpa에 관한 설정을 변경하였고,
 Jpa는 Identity 전략을 사용하면 Bulk Insert를 쓸 수 없었기 때문에 직접 Jdbc를 활용해 BulkInsert문을 구현했습니다.
 
![{1CF87FD2-8092-485D-97B0-A8917674D027}](https://github.com/user-attachments/assets/a8e9cdc3-490a-4f87-9c3c-a55334d12ec1)


 이를 통해 Market을 저장하는 시간이 약 270ms 에서 24ms로 단축될 수 있었습니다.
 
 ## WebClient 비동기화를 통한 성능 최적화
 위와 같은 방법을 통해 성능을 최적화해봤지만 그래도 1초 이상의 시간이 소모되었습니다.
 가장 큰 문제는 외부 API를 호출하는 부분에서 900ms이상 소모한다는 것이었습니다.
 
 이 API의 경우 단순히 저장하는 용도이고, 별도의 응답이 없기 때문에 WebClient를 비동기화하여 성능을 최적화할 수 있었습니다.
 
```
	// market api를 요청하고 가져온 데이터를 저장하는 메서드
	private void requestAndSaveMarkets(int totalPage) {
		long startTime = System.currentTimeMillis();
		for (int i = 1; i <= totalPage; i++) {
			String url = marketProperties.getMarketApiUrl();

			MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
			params.add(marketProperties.getParamPage(), String.valueOf(i));
			params.add(marketProperties.getParamPerPage(), marketProperties.getMarketApiRequestUnit().toString());

			MarketApiResponse response = webClientUtil.getMarket(url, params, MarketApiResponse.class);

			if (!Objects.nonNull(response)) {
				throw new CustomException(CommonErrorCode.EXTERNAL_SERVER_ERROR);
			}

			List<Market> markets = response.getData().stream().map(Market::from).distinct().toList();

			saveAllMarket(markets);
		}

		long stopTime = System.currentTimeMillis();
		log.info("requestANdSaveMarkets: {}", stopTime - startTime);
	}

```
기존 코드에서는 각 페이지별로 정보를 가져와 저장하였습니다.
이 로직을 Page별 요청을 비동기화하고, 추후 응답을 Mono를 통해 받아 save를 호출하게 했습니다.

이를 통해 동기적으로 페이지를 호출하는 상황에서 비동기적으로 변환되어 모든 호출이 0.4초 이내에 끝나 성능이 개선되었고
요청 자체도 비동기로 동작했기에 요청에서 응답까지의 시간이 100ms대로 개선되었습니다.

# 참고 사항
application.properties 및 application-security.properties가 변경되었습니다!
