### PR TITLE
Refactor: AuthenticationToken에 Email 대신 MemberId 저장 및 그에 따른 로직 변경

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/common/security/filter/jwtFilter/JwtTokenProviderImpl.java
+++ b/backend/src/main/java/middle_point_search/backend/common/security/filter/jwtFilter/JwtTokenProviderImpl.java
@@ -65,12 +65,9 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> CustomException.from(MEMBER_NOT_FOUND));
 
-		String email = member.getEmail();
-		String pw = member.getPw();
-
 		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(member.getRole().getValue()));
 
-		return UsernamePasswordAuthenticationToken.authenticated(email, pw, authorities);
+		return UsernamePasswordAuthenticationToken.authenticated(memberId, null, authorities);
 	}
 
 	@Override

--- a/backend/src/main/java/middle_point_search/backend/common/util/MemberLoader.java
+++ b/backend/src/main/java/middle_point_search/backend/common/util/MemberLoader.java
@@ -20,15 +20,14 @@ public class MemberLoader {
 
 	// Authentication 객체에서 Member를 찾는 메서드
 	public Member getMember() {
-		String email = getEmail();
+		Long memberId = getMemberId();
 
-		return memberRepository.findByEmail(email)
+		return memberRepository.findById(memberId)
 			.orElseThrow(() -> CustomException.from(MEMBER_NOT_FOUND));
 	}
 
-	// Authentication 객체에서 email을 추출하는 메서드
-	public String getEmail() {
-		return (String)SecurityContextHolder
+	public Long getMemberId() {
+		return (Long)SecurityContextHolder
 			.getContext()
 			.getAuthentication()
 			.getPrincipal();

--- a/backend/src/main/java/middle_point_search/backend/domains/member/controller/MemberController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/member/controller/MemberController.java
@@ -20,7 +20,6 @@ import middle_point_search.backend.common.dto.DataResponse;
 import middle_point_search.backend.common.dto.ErrorResponse;
 import middle_point_search.backend.common.security.filter.jwtFilter.JwtTokenProvider;
 import middle_point_search.backend.common.util.MemberLoader;
-import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.member.dto.MemberDTO.MemberCreateRequest;
 import middle_point_search.backend.domains.member.service.MemberService;
 
@@ -85,9 +84,9 @@ public class MemberController {
 	)
 	public ResponseEntity<DataResponse<Void>> memberLogout(HttpServletRequest request) {
 		String accessToken = jwtTokenProvider.extractAccessToken(request).orElse(null);
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		memberService.logoutMember(member, accessToken);
+		memberService.logoutMember(memberId, accessToken);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/member/service/MemberService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/member/service/MemberService.java
@@ -36,9 +36,7 @@ public class MemberService {
 
 	// 회원 로그아웃 하기
 	@Transactional
-	public void logoutMember(Member member, String accessToken) {
-		Long memberId = member.getId();
-
+	public void logoutMember(Long memberId, String accessToken) {
 		// 회원의 refreshToken 삭제
 		refreshTokenService.deleteByMemberId(memberId);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomController.java
@@ -94,9 +94,9 @@ public class MemberRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<List<RoomsByMemberIdFindResponse>>> findRooms() {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		List<RoomsByMemberIdFindResponse> responses = memberRoomService.findRooms(member);
+		List<RoomsByMemberIdFindResponse> responses = memberRoomService.findRooms(memberId);
 
 		return ResponseEntity.ok(DataResponse.from(responses));
 	}
@@ -124,9 +124,12 @@ public class MemberRoomController {
 	)
 	public ResponseEntity<DataResponse<MemberRoomExistsResponse>> existsMemberRoom(
 		@PathVariable("roomId") Long roomId) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		MemberRoomExistsResponse response = memberRoomService.existsMemberRoom(member.getId(), roomId);
+		System.out.println("memberId: " + memberId);
+
+
+		MemberRoomExistsResponse response = memberRoomService.existsMemberRoom(memberId, roomId);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import middle_point_search.backend.domains.member.domain.Member;
-
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
 	Boolean existsByMember_IdAndRoom_Id(Long memberId, Long roomId);
 
-	List<MemberRoom> findByMember(Member member);
+	List<MemberRoom> findByMember_Id(Long memberId);
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomService.java
@@ -44,8 +44,8 @@ public class MemberRoomService {
 	}
 
 	// 회원이 속한 방들을 DTO로 조회
-	public List<RoomsByMemberIdFindResponse> findRooms(Member member) {
-		List<MemberRoom> memberRooms = memberRoomRepository.findByMember(member);
+	public List<RoomsByMemberIdFindResponse> findRooms(Long memberId) {
+		List<MemberRoom> memberRooms = memberRoomRepository.findByMember_Id(memberId);
 
 		return memberRooms.stream()
 			.map(memberRoom -> RoomsByMemberIdFindResponse.from(memberRoom.getRoom()))

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import middle_point_search.backend.common.dto.DataResponse;
 import middle_point_search.backend.common.dto.ErrorResponse;
 import middle_point_search.backend.common.util.MemberLoader;
-import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.midPoint.dto.MidPointDTO.MidPointsFindResponse;
 import middle_point_search.backend.domains.midPoint.service.MidPointService;
 
@@ -72,9 +71,9 @@ public class MidPointController {
 	public ResponseEntity<DataResponse<List<MidPointsFindResponse>>> MidPointsFind(
 		@PathVariable("roomId") Long roomId
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		List<MidPointsFindResponse> midPoints = midPointService.findMidPointsByRoomId(member.getId(), roomId);
+		List<MidPointsFindResponse> midPoints = midPointService.findMidPointsByRoomId(memberId, roomId);
 
 		return ResponseEntity.ok(DataResponse.from(midPoints));
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/place/controller/PlaceController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/controller/PlaceController.java
@@ -115,9 +115,9 @@ public class PlaceController {
 	public ResponseEntity<DataResponse<PlacesFindResponse>> placesFind(
 		@PathVariable("roomId") Long roomId
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		PlacesFindResponse response = placeService.findPlaces(member.getId(), roomId);
+		PlacesFindResponse response = placeService.findPlaces(memberId, roomId);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
@@ -159,9 +159,9 @@ public class PlaceController {
 	public ResponseEntity<DataResponse<Void>> placeDelete(
 		@PathVariable("roomId") Long roomId
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		placeService.deletePlace(member.getId(), roomId);
+		placeService.deletePlace(memberId, roomId);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteController.java
@@ -76,10 +76,10 @@ public class PlaceVoteController {
 	public ResponseEntity<DataResponse<List<PlaceVoteResultsFindResponse>>> placeVoteRoomResultGet(
 		@PathVariable("roomId") Long roomId
 	) {
-		Member member = memberLoader.getMember();
-		List<PlaceVoteResultsFindResponse> response = placeVoteRoomService.findPlaceVoteResults(
-			member.getId(),
-			roomId);
+		Long memberId = memberLoader.getMemberId();
+
+		List<PlaceVoteResultsFindResponse> response = placeVoteRoomService.findPlaceVoteResults(memberId, roomId);
+
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
 

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteRoomController.java
@@ -21,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import middle_point_search.backend.common.dto.DataResponse;
 import middle_point_search.backend.common.dto.ErrorResponse;
 import middle_point_search.backend.common.util.MemberLoader;
-import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.placeVoteRoom.dto.PlaceVoteDTO;
 import middle_point_search.backend.domains.placeVoteRoom.service.PlaceVoteRoomService;
 
@@ -82,9 +81,9 @@ public class PlaceVoteRoomController {
 		@PathVariable("roomId") Long roomId,
 		@RequestBody @Valid PlaceVoteRoomCreateRequest request
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 		PlaceVoteRoomCreateResponse response = placeVoteRoomService.createPlaceVoteRoom(
-			member.getId(),
+			memberId,
 			roomId,
 			request);
 
@@ -141,9 +140,9 @@ public class PlaceVoteRoomController {
 		@PathVariable("roomId") Long roomId,
 		@RequestBody @Valid PlaceVoteRoomCreateRequest request
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		placeVoteRoomService.UpdatePlaceVoteRoom(member.getId(), roomId, request);
+		placeVoteRoomService.UpdatePlaceVoteRoom(memberId, roomId, request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -181,9 +180,10 @@ public class PlaceVoteRoomController {
 	public ResponseEntity<DataResponse<PlaceVoteDTO.PlaceVoteCandidatesFindResponse>> placeVoteRoomFind(
 		@PathVariable("roomId") Long roomId
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
+
 		PlaceVoteDTO.PlaceVoteCandidatesFindResponse response = placeVoteRoomService.findPlaceVoteCandidates(
-			member.getId(),
+			memberId,
 			roomId);
 
 		return ResponseEntity.ok(DataResponse.from(response));

--- a/backend/src/main/java/middle_point_search/backend/domains/room/controller/RoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/controller/RoomController.java
@@ -18,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import middle_point_search.backend.common.dto.DataResponse;
 import middle_point_search.backend.common.dto.ErrorResponse;
 import middle_point_search.backend.common.util.MemberLoader;
-import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.room.dto.RoomDTO.RoomCreateRequest;
 import middle_point_search.backend.domains.room.dto.RoomDTO.RoomCreateResponse;
 import middle_point_search.backend.domains.room.dto.RoomDTO.RoomNameUpdateRequest;
@@ -101,9 +100,9 @@ public class RoomController {
 		@PathVariable Long roomId,
 		@RequestBody RoomNameUpdateRequest request
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		roomService.updateRoomName(member.getId(), roomId, request);
+		roomService.updateRoomName(memberId, roomId, request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteController.java
@@ -220,9 +220,9 @@ public class TimeVoteController {
 	public ResponseEntity<DataResponse<TimeVoteRoomResultResponse>> timeVoteResultsGet(
 		@PathVariable Long roomId
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		TimeVoteRoomResultResponse result = timeVoteRoomService.findTimeVoteResult(member.getId(), roomId);
+		TimeVoteRoomResultResponse result = timeVoteRoomService.findTimeVoteResult(memberId, roomId);
 
 		return ResponseEntity.ok(DataResponse.from(result));
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteRoomController.java
@@ -21,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import middle_point_search.backend.common.dto.DataResponse;
 import middle_point_search.backend.common.dto.ErrorResponse;
 import middle_point_search.backend.common.util.MemberLoader;
-import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.timeVoteRoom.service.TimeVoteRoomService;
 
 @Tag(name = "TIME VOTE ROOM API", description = "시간투표방에 대한 API입니다.")
@@ -78,9 +77,9 @@ public class TimeVoteRoomController {
 		@PathVariable("roomId") Long roomId,
 		@RequestBody @Valid TimeVoteRoomCreateRequest request
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		TimeVoteRoomCreateResponse response = timeVoteRoomService.createTimeVoteRoom(member.getId(), roomId, request);
+		TimeVoteRoomCreateResponse response = timeVoteRoomService.createTimeVoteRoom(memberId, roomId, request);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}
@@ -130,9 +129,9 @@ public class TimeVoteRoomController {
 		@PathVariable("roomId") Long roomId,
 		@RequestBody @Valid TimeVoteRoomCreateRequest request
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		timeVoteRoomService.updateTimeVoteRoom(member.getId(), roomId, request);
+		timeVoteRoomService.updateTimeVoteRoom(memberId, roomId, request);
 
 		return ResponseEntity.ok(DataResponse.ok());
 	}
@@ -169,9 +168,9 @@ public class TimeVoteRoomController {
 	public ResponseEntity<DataResponse<TimeVoteRoomGetResponse>> timeVoteRoomGet(
 		@PathVariable("roomId") Long roomId
 	) {
-		Member member = memberLoader.getMember();
+		Long memberId = memberLoader.getMemberId();
 
-		TimeVoteRoomGetResponse response = timeVoteRoomService.findTimeVoteRoomAndMakeDTO(member.getId(), roomId);
+		TimeVoteRoomGetResponse response = timeVoteRoomService.findTimeVoteRoomAndMakeDTO(memberId, roomId);
 
 		return ResponseEntity.ok(DataResponse.from(response));
 	}


### PR DESCRIPTION
## 개요
- close #148 

## 구현 의도
기존 로직에서는 APi를 호출할 때마다 Security와 Servlet단 모두에서 Member를 조회하고 있었습니다.
이러한 불필요한 쿼리 호출을 줄이는 게 목표였습니다.

## 작업사항
### UsernamePasswordAuthenticationToken에 저장하는 정보 변경
![image](https://github.com/user-attachments/assets/ba08a33c-63b5-40a4-aa5c-c3dad0c9c291)

이 객체의 Pricipal은 Object로 구현되어 있습니다. 즉 어떤 객체가 들어가도 무관하기에
기존의 Email에서 MemberId로 변경했습니다.

이로 인해  불필요한 쿼리문이 1번 줄어들게 되었습니다.
서블릿 단에서 필요할 때 MemberLoader를 통해 Member를 조회해올 수 있게했습니다.
무조건 Controller에는 MemberId를 넘기고 Service에서 Member를 조회할 수 있었지만 코드에 중복도 존재하게 되고
너무 많은 곳에서 MemberRepository를 의존성 주입하는 게 좋아보이지  않았습니다,

### 서블릿단애서 불필요한 Member 조회 제거
비즈니스로직에서 MemberId로만 해결되는 경우 MemberId만 넘겨주도록 변경했습니다.
## 