### PR TITLE
Feature: roomId를 uuid로 변경

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomController.java
@@ -62,7 +62,7 @@ public class MemberRoomController {
 			)
 		}
 	)
-	public ResponseEntity<DataResponse<Void>> saveMemberToRoom(@PathVariable("roomId") Long roomId) {
+	public ResponseEntity<DataResponse<Void>> saveMemberToRoom(@PathVariable("roomId") String roomId) {
 		Member member = memberLoader.getMember();
 
 		memberRoomService.saveMemberToRoom(member, roomId);
@@ -123,11 +123,9 @@ public class MemberRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<MemberRoomExistsResponse>> existsMemberRoom(
-		@PathVariable("roomId") Long roomId) {
+		@PathVariable("roomId") String roomId
+	) {
 		Long memberId = memberLoader.getMemberId();
-
-		System.out.println("memberId: " + memberId);
-
 
 		MemberRoomExistsResponse response = memberRoomService.existsMemberRoom(memberId, roomId);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomDTO.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomDTO.java
@@ -20,7 +20,7 @@ public class MemberRoomDTO {
 	@Getter
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class RoomsByMemberIdFindResponse {
-		private Long roomId;
+		private String roomId;
 		private String roomName;
 
 		public static RoomsByMemberIdFindResponse from(Room room) {

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 
-	Boolean existsByMember_IdAndRoom_Id(Long memberId, Long roomId);
+	Boolean existsByMember_IdAndRoom_Id(Long memberId, String roomId);
 
 	List<MemberRoom> findByMember_Id(Long memberId);
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomService.java
@@ -26,7 +26,7 @@ public class MemberRoomService {
 
 	// 회원방을 DTO로 저장
 	@Transactional(rollbackFor = CustomException.class)
-	public void saveMemberToRoom(Member member, Long roomId) {
+	public void saveMemberToRoom(Member member, String roomId) {
 		// 방조회
 		Room room = roomService.findRoom(roomId)
 			.orElseThrow(() -> CustomException.from(ROOM_NOT_FOUND));
@@ -53,7 +53,7 @@ public class MemberRoomService {
 	}
 
 	// 회원방이 존재하는지 확인
-	public MemberRoomExistsResponse existsMemberRoom(Long memberId, Long roomId) {
+	public MemberRoomExistsResponse existsMemberRoom(Long memberId, String roomId) {
 		Boolean exists = memberRoomRepository.existsByMember_IdAndRoom_Id(memberId, roomId);
 
 		return MemberRoomExistsResponse.from(exists);

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomValidateService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/MemberRoomValidateService.java
@@ -27,7 +27,7 @@ public class MemberRoomValidateService {
 	}
 
 	// 방에 존재하는 회원인지 판별
-	public void validateAuthorizedMember(Long memberId, Long roomId) {
+	public void validateAuthorizedMember(Long memberId, String roomId) {
 		if (!memberRoomRepository.existsByMember_IdAndRoom_Id(memberId, roomId)) {
 			throw CustomException.from(UNAUTHORIZED_MEMBER_ROOM);
 		}

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/controller/MidPointController.java
@@ -71,7 +71,7 @@ public class MidPointController {
 		}
 	)
 	public ResponseEntity<DataResponse<List<MidPointsFindResponse>>> MidPointsFind(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("roomId") String roomId
 	) {
 		Long memberId = memberLoader.getMemberId();
 
@@ -125,7 +125,7 @@ public class MidPointController {
 		}
 	)
 	public ResponseEntity<DataResponse<TravelTimesFindResponse>> findPath(
-		@PathVariable Long roomId,
+		@PathVariable String roomId,
 		@RequestParam Double destLatitude,
 		@RequestParam Double destLongitude
 	) {

--- a/backend/src/main/java/middle_point_search/backend/domains/midPoint/service/MidPointService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/midPoint/service/MidPointService.java
@@ -36,7 +36,7 @@ public class MidPointService {
 	}
 
 	// 주어진 RoomId로 중간 장소 리스트를 조회하는 메서드
-	public List<MidPointsFindResponse> findMidPointsByRoomId(Long memberId, Long roomId) {
+	public List<MidPointsFindResponse> findMidPointsByRoomId(Long memberId, String roomId) {
 		// 회원이 방에 속해있는지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -49,7 +49,7 @@ public class MidPointService {
 	}
 
 	// 방 장소들의 중간지점까지의 이동시간을 조회하는 메서드
-	public TravelTimesFindResponse findTravelTimes(Long roomId, Long memberId, Double latitude, Double longitude) {
+	public TravelTimesFindResponse findTravelTimes(String roomId, Long memberId, Double latitude, Double longitude) {
 		// 회원이 방에 속해있는지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/place/controller/PlaceController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/controller/PlaceController.java
@@ -70,7 +70,7 @@ public class PlaceController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> placeSave(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid SavePlaceRequest request
 	) {
 		Member member = memberLoader.getMember();
@@ -115,7 +115,7 @@ public class PlaceController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> updatePlace(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid UpdatePlaceRequest request
 	) {
 		Member member = memberLoader.getMember();
@@ -162,7 +162,7 @@ public class PlaceController {
 		}
 	)
 	public ResponseEntity<DataResponse<FindPlacesResponse>> placesFind(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("roomId") String roomId
 	) {
 		Long memberId = memberLoader.getMemberId();
 

--- a/backend/src/main/java/middle_point_search/backend/domains/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/repository/PlaceRepository.java
@@ -11,9 +11,9 @@ import middle_point_search.backend.domains.place.domain.Place;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-	List<Place> findAllByRoom_Id(Long roomId);
+	List<Place> findAllByRoom_Id(String roomId);
 
-	void deleteByIdAndRoom_Id(Long placeId, Long roomId);
+	void deleteByIdAndRoom_Id(Long placeId, String roomId);
 
 	@Modifying
 	@Query("UPDATE Place p " +

--- a/backend/src/main/java/middle_point_search/backend/domains/place/service/PlaceService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/service/PlaceService.java
@@ -33,7 +33,7 @@ public class PlaceService {
 	private final GoogleService googleService;
 
 	// 장소 조회
-	public FindPlacesResponse findPlaces(Long memberId, Long roomId) {
+	public FindPlacesResponse findPlaces(Long memberId, String roomId) {
 		// 회원이 방에 속해있는지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -58,7 +58,7 @@ public class PlaceService {
 
 	//장소 저장
 	@Transactional(rollbackFor = {CustomException.class})
-	public void savePlace(Long roomId, Member member, SavePlaceRequest request) {
+	public void savePlace(String roomId, Member member, SavePlaceRequest request) {
 		// 회원이 방에 속해있는지 확인
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 
@@ -73,7 +73,7 @@ public class PlaceService {
 
 	//장소 업데이트
 	@Transactional(rollbackFor = {CustomException.class})
-	public void updatePlace(Long roomId, Member member, UpdatePlaceRequest request) {
+	public void updatePlace(String roomId, Member member, UpdatePlaceRequest request) {
 		// 회원이 방에 속해있는지 확인
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteController.java
@@ -74,7 +74,7 @@ public class PlaceVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<List<PlaceVoteResultsFindResponse>>> placeVoteRoomResultGet(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("roomId") String roomId
 	) {
 		Long memberId = memberLoader.getMemberId();
 
@@ -128,7 +128,7 @@ public class PlaceVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> vote(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid PlaceVoteRequest request
 	) {
 		Member member = memberLoader.getMember();
@@ -177,7 +177,7 @@ public class PlaceVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> voteUpdate(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid PlaceVoteRequest request
 	) {
 		Member member = memberLoader.getMember();
@@ -217,7 +217,7 @@ public class PlaceVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<VotedAndVoteItemResponse>> votedAndVoteItemFind(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("roomId") String roomId
 	) {
 		Member member = memberLoader.getMember();
 

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/controller/PlaceVoteRoomController.java
@@ -78,7 +78,7 @@ public class PlaceVoteRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<PlaceVoteRoomCreateResponse>> placeVoteRoomCreate(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid PlaceVoteRoomCreateRequest request
 	) {
 		Long memberId = memberLoader.getMemberId();
@@ -137,7 +137,7 @@ public class PlaceVoteRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> placeVoteRoomUpdate(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid PlaceVoteRoomCreateRequest request
 	) {
 		Long memberId = memberLoader.getMemberId();
@@ -178,7 +178,7 @@ public class PlaceVoteRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<PlaceVoteDTO.PlaceVoteCandidatesFindResponse>> placeVoteRoomFind(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("roomId") String roomId
 	) {
 		Long memberId = memberLoader.getMemberId();
 

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/repository/PlaceVoteCandidateMemberRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/repository/PlaceVoteCandidateMemberRepository.java
@@ -12,7 +12,7 @@ public interface PlaceVoteCandidateMemberRepository extends JpaRepository<PlaceV
 
 	boolean existsByPlaceVoteCandidate_PlaceVoteRoomAndMember(PlaceVoteRoom placeVoteRoom, Member member);
 
-	Optional<PlaceVoteCandidateMember> findByPlaceVoteCandidate_PlaceVoteRoom_Room_IdAndMember(Long roomId,
+	Optional<PlaceVoteCandidateMember> findByPlaceVoteCandidate_PlaceVoteRoom_Room_IdAndMember(String roomId,
 		Member member);
 
 	void deleteByPlaceVoteCandidate_PlaceVoteRoomAndMember(PlaceVoteRoom placeVoteRoom, Member member);

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/repository/PlaceVoteCandidateRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/repository/PlaceVoteCandidateRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import middle_point_search.backend.domains.placeVoteRoom.domain.PlaceVoteCandidate;
 
 public interface PlaceVoteCandidateRepository extends JpaRepository<PlaceVoteCandidate, Long> {
-	Optional<PlaceVoteCandidate> findById(Long id);
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/repository/PlaceVoteRoomRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/repository/PlaceVoteRoomRepository.java
@@ -5,15 +5,14 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import middle_point_search.backend.domains.placeVoteRoom.domain.PlaceVoteRoom;
-import middle_point_search.backend.domains.room.domain.Room;
 
 public interface PlaceVoteRoomRepository extends JpaRepository<PlaceVoteRoom, Long> {
 
-	boolean existsByRoom_Id(Long roomId);
+	boolean existsByRoom_Id(String roomId);
 
-	void deleteByRoom_Id(Long roomId);
+	void deleteByRoom_Id(String roomId);
 
-	Optional<PlaceVoteRoom> findByRoom_Id(Long roomId);
+	Optional<PlaceVoteRoom> findByRoom_Id(String roomId);
 
 }
 

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/service/PlaceVoteRoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/service/PlaceVoteRoomService.java
@@ -31,8 +31,11 @@ public class PlaceVoteRoomService {
 
 	// 장소투표방 생성
 	@Transactional(rollbackFor = {CustomException.class})
-	public PlaceVoteRoomCreateResponse createPlaceVoteRoom(Long memberId, Long roomId,
-		PlaceVoteRoomCreateRequest request) {
+	public PlaceVoteRoomCreateResponse createPlaceVoteRoom(
+		Long memberId,
+		String roomId,
+		PlaceVoteRoomCreateRequest request
+	) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -56,7 +59,7 @@ public class PlaceVoteRoomService {
 
 	//장소투표방 리셋
 	@Transactional(rollbackFor = {CustomException.class})
-	public void UpdatePlaceVoteRoom(Long memberId, Long roomId, PlaceVoteRoomCreateRequest request) {
+	public void UpdatePlaceVoteRoom(Long memberId, String roomId, PlaceVoteRoomCreateRequest request) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -73,12 +76,12 @@ public class PlaceVoteRoomService {
 	}
 
 	// 장소투표방 조회
-	public Optional<PlaceVoteRoom> findByRoomId(Long roomId) {
+	public Optional<PlaceVoteRoom> findByRoomId(String roomId) {
 		return placeVoteRoomRepository.findByRoom_Id(roomId);
 	}
 
 	// 장소투표방 중복 체크
-	private void validateDuplicatePlaceVoteRoom(Long roomId) {
+	private void validateDuplicatePlaceVoteRoom(String roomId) {
 		boolean exists = placeVoteRoomRepository.existsByRoom_Id(roomId);
 		if (exists) {
 			throw CustomException.from(DUPLICATE_VOTE_ROOM);
@@ -86,7 +89,7 @@ public class PlaceVoteRoomService {
 	}
 
 	// 장소투표방 존재 여부 확인, 존재시 true, 존재하지 않을시 false 반환
-	public PlaceVoteDTO.PlaceVoteCandidatesFindResponse findPlaceVoteCandidates(Long memberId, Long roomId) {
+	public PlaceVoteDTO.PlaceVoteCandidatesFindResponse findPlaceVoteCandidates(Long memberId, String roomId) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/service/PlaceVoteService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/placeVoteRoom/service/PlaceVoteService.java
@@ -34,7 +34,7 @@ public class PlaceVoteService {
 
 	// 투표 처리
 	@Transactional(rollbackFor = {CustomException.class})
-	public void vote(Member member, Long roomId, PlaceVoteRequest voteRequest) {
+	public void vote(Member member, String roomId, PlaceVoteRequest voteRequest) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 
@@ -60,7 +60,7 @@ public class PlaceVoteService {
 
 	// 재투표
 	@Transactional(rollbackFor = {CustomException.class})
-	public void updateVote(Member member, Long roomId, PlaceVoteRequest voteRequest) {
+	public void updateVote(Member member, String roomId, PlaceVoteRequest voteRequest) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 
@@ -87,7 +87,7 @@ public class PlaceVoteService {
 	}
 
 	// 내 투표 조회
-	public VotedAndVoteItemResponse findVotedAndVoteItem(Member member, Long roomId) {
+	public VotedAndVoteItemResponse findVotedAndVoteItem(Member member, String roomId) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 
@@ -103,7 +103,7 @@ public class PlaceVoteService {
 	}
 
 	// 장소투표 결과 조회
-	public List<PlaceVoteResultsFindResponse> findPlaceVoteResults(Long memberId, Long roomId) {
+	public List<PlaceVoteResultsFindResponse> findPlaceVoteResults(Long memberId, String roomId) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 

--- a/backend/src/main/java/middle_point_search/backend/domains/room/controller/RoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/controller/RoomController.java
@@ -101,7 +101,7 @@ public class RoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> roomNameUpdate(
-		@PathVariable Long roomId,
+		@PathVariable String roomId,
 		@RequestBody RoomNameUpdateRequest request
 	) {
 		Long memberId = memberLoader.getMemberId();
@@ -138,7 +138,7 @@ public class RoomController {
 			),
 		}
 	)
-	public ResponseEntity<DataResponse<RoomExistResponse>> roomExist(@PathVariable Long roomId) {
+	public ResponseEntity<DataResponse<RoomExistResponse>> roomExist(@PathVariable String roomId) {
 		RoomExistResponse response = roomService.existRoom(roomId);
 
 		return ResponseEntity.ok(DataResponse.from(response));

--- a/backend/src/main/java/middle_point_search/backend/domains/room/domain/Room.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/domain/Room.java
@@ -10,8 +10,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
@@ -29,12 +27,8 @@ import middle_point_search.backend.domains.place.domain.Place;
 public class Room extends BaseEntity {
 
 	@Id
-	@Column(name = "room_id")
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
-	@Column(nullable = false, length = 36)
-	private String identityKey; // url 이동을 위한 식별키
+	@Column(name = "room_id", nullable = false, length = 36)
+	private String id;
 
 	@OneToMany(mappedBy = "room", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private List<Place> places = new ArrayList<>();
@@ -46,9 +40,9 @@ public class Room extends BaseEntity {
 	private List<MemberRoom> memberRooms = new ArrayList<>();
 
 	@Builder
-	private Room(String name, String identityKey) {
+	private Room(String name, String id) {
 		this.name = name;
-		this.identityKey = identityKey;
+		this.id = id;
 	}
 
 	public void updateName(String name) {

--- a/backend/src/main/java/middle_point_search/backend/domains/room/domain/Room.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/domain/Room.java
@@ -33,6 +33,9 @@ public class Room extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(nullable = false, length = 36)
+	private String identityKey; // url 이동을 위한 식별키
+
 	@OneToMany(mappedBy = "room", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private List<Place> places = new ArrayList<>();
 
@@ -43,8 +46,9 @@ public class Room extends BaseEntity {
 	private List<MemberRoom> memberRooms = new ArrayList<>();
 
 	@Builder
-	private Room(String name) {
+	private Room(String name, String identityKey) {
 		this.name = name;
+		this.identityKey = identityKey;
 	}
 
 	public void updateName(String name) {

--- a/backend/src/main/java/middle_point_search/backend/domains/room/dto/RoomDTO.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/dto/RoomDTO.java
@@ -12,9 +12,9 @@ public class RoomDTO {
 	@Getter
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class RoomCreateResponse {
-		private final Long id;
+		private final String id;
 
-		public static RoomCreateResponse from(Long id) {
+		public static RoomCreateResponse from(String id) {
 			return new RoomCreateResponse(id);
 		}
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/room/repository/RoomRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/repository/RoomRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import middle_point_search.backend.domains.room.domain.Room;
 
-public interface RoomRepository extends JpaRepository<Room, Long> {
+public interface RoomRepository extends JpaRepository<Room, String> {
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/room/service/RoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/service/RoomService.java
@@ -3,6 +3,7 @@ package middle_point_search.backend.domains.room.service;
 import static middle_point_search.backend.common.exception.errorCode.UserErrorCode.*;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +31,7 @@ public class RoomService {
 	public RoomCreateResponse createRoom(RoomCreateRequest request) {
 		Room room = Room.builder()
 			.name(request.getName())
+			.identityKey(UUID.randomUUID().toString())
 			.build();
 
 		// Room저장

--- a/backend/src/main/java/middle_point_search/backend/domains/room/service/RoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/room/service/RoomService.java
@@ -31,7 +31,7 @@ public class RoomService {
 	public RoomCreateResponse createRoom(RoomCreateRequest request) {
 		Room room = Room.builder()
 			.name(request.getName())
-			.identityKey(UUID.randomUUID().toString())
+			.id(UUID.randomUUID().toString())
 			.build();
 
 		// Room저장
@@ -42,7 +42,7 @@ public class RoomService {
 
 	// Room 이름 변경하기
 	@Transactional(rollbackFor = CustomException.class)
-	public void updateRoomName(Long memberId, Long roomId, RoomNameUpdateRequest request) {
+	public void updateRoomName(Long memberId, String roomId, RoomNameUpdateRequest request) {
 		// 회원방 존재 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -53,13 +53,13 @@ public class RoomService {
 	}
 
 	// Room 조회
-	public Optional<Room> findRoom(Long id) {
+	public Optional<Room> findRoom(String id) {
 		return roomRepository.findById(id);
 	}
 
 
 	// 방 존재 확인
-	public RoomExistResponse existRoom(Long roomId) {
+	public RoomExistResponse existRoom(String roomId) {
 		return RoomExistResponse.from(roomRepository.existsById(roomId));
 	}
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteController.java
@@ -79,7 +79,7 @@ public class TimeVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> vote(
-		@PathVariable Long roomId,
+		@PathVariable String roomId,
 		@RequestBody @Valid VoteRequest request
 	) {
 		Member member = memberLoader.getMember();
@@ -129,7 +129,7 @@ public class TimeVoteController {
 		}
 	)
 	public ResponseEntity<?> voteUpdate(
-		@PathVariable Long roomId,
+		@PathVariable String roomId,
 		@RequestBody @Valid VoteRequest request
 	) {
 		Member member = memberLoader.getMember();
@@ -174,7 +174,7 @@ public class TimeVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<VotedAndVoteItemsGetResponse>> votedAndVoteItemsGet(
-		@PathVariable Long roomId
+		@PathVariable String roomId
 	) {
 		Member member = memberLoader.getMember();
 
@@ -218,7 +218,7 @@ public class TimeVoteController {
 		}
 	)
 	public ResponseEntity<DataResponse<TimeVoteRoomResultResponse>> timeVoteResultsGet(
-		@PathVariable Long roomId
+		@PathVariable String roomId
 	) {
 		Long memberId = memberLoader.getMemberId();
 

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/controller/TimeVoteRoomController.java
@@ -74,7 +74,7 @@ public class TimeVoteRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<TimeVoteRoomCreateResponse>> timeVoteRoomCreate(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid TimeVoteRoomCreateRequest request
 	) {
 		Long memberId = memberLoader.getMemberId();
@@ -126,7 +126,7 @@ public class TimeVoteRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<Void>> timeVoteRoomRecreate(
-		@PathVariable("roomId") Long roomId,
+		@PathVariable("roomId") String roomId,
 		@RequestBody @Valid TimeVoteRoomCreateRequest request
 	) {
 		Long memberId = memberLoader.getMemberId();
@@ -166,7 +166,7 @@ public class TimeVoteRoomController {
 		}
 	)
 	public ResponseEntity<DataResponse<TimeVoteRoomGetResponse>> timeVoteRoomGet(
-		@PathVariable("roomId") Long roomId
+		@PathVariable("roomId") String roomId
 	) {
 		Long memberId = memberLoader.getMemberId();
 

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/repository/TimeVoteRoomRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/repository/TimeVoteRoomRepository.java
@@ -7,9 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import middle_point_search.backend.domains.timeVoteRoom.domain.TimeVoteRoom;
 
 public interface TimeVoteRoomRepository extends JpaRepository<TimeVoteRoom, Long> {
-	boolean existsByRoom_Id(Long roomId);
+	boolean existsByRoom_Id(String roomId);
 
-	Optional<TimeVoteRoom> findByRoom_Id(Long roomId);
-
-	void deleteByRoom_Id(Long roomId);
+	Optional<TimeVoteRoom> findByRoom_Id(String roomId);
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/service/TimeVoteRoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/service/TimeVoteRoomService.java
@@ -30,7 +30,7 @@ public class TimeVoteRoomService {
 
 	// 시간 투표방 생성
 	@Transactional(rollbackFor = {CustomException.class})
-	public TimeVoteRoomCreateResponse createTimeVoteRoom(Long memberId, Long roomId, TimeVoteRoomCreateRequest request) {
+	public TimeVoteRoomCreateResponse createTimeVoteRoom(Long memberId, String roomId, TimeVoteRoomCreateRequest request) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -57,7 +57,7 @@ public class TimeVoteRoomService {
 
 	//시간투표방 변경하기
 	@Transactional(rollbackFor = {CustomException.class})
-	public void updateTimeVoteRoom(Long memberId, Long roomId, TimeVoteRoomCreateRequest request) {
+	public void updateTimeVoteRoom(Long memberId, String roomId, TimeVoteRoomCreateRequest request) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -73,7 +73,7 @@ public class TimeVoteRoomService {
 	}
 
 	// 시간투표방 조회
-	public TimeVoteRoomGetResponse findTimeVoteRoomAndMakeDTO(Long memberId, Long roomId) {
+	public TimeVoteRoomGetResponse findTimeVoteRoomAndMakeDTO(Long memberId, String roomId) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -91,7 +91,7 @@ public class TimeVoteRoomService {
 	}
 
 	// 시간 투표방, 방으로 조회
-	public Optional<TimeVoteRoom> findByRoomId(Long roomId) {
+	public Optional<TimeVoteRoom> findByRoomId(String roomId) {
 		return timeVoteRoomRepository.findByRoom_Id(roomId);
 	}
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/service/TimeVoteService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/timeVoteRoom/service/TimeVoteService.java
@@ -42,7 +42,7 @@ public class TimeVoteService {
 	@Transactional(rollbackFor = {CustomException.class})
 	public void vote(
 		Member member,
-		Long roomId,
+		String roomId,
 		VoteRequest request
 	) {
 		// 방에 대한 회원인지 확인
@@ -69,7 +69,7 @@ public class TimeVoteService {
 	@Transactional(rollbackFor = {CustomException.class})
 	public void updateVote(
 		Member member,
-		Long roomId,
+		String roomId,
 		VoteRequest request
 	) {
 		// 방에 대한 회원인지 확인
@@ -120,7 +120,7 @@ public class TimeVoteService {
 	}
 
 	// 시간 투표 현황 정보 조회
-	public TimeVoteRoomResultResponse findTimeVoteResult(Long memberId, Long roomId) {
+	public TimeVoteRoomResultResponse findTimeVoteResult(Long memberId, String roomId) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(memberId, roomId);
 
@@ -196,7 +196,7 @@ public class TimeVoteService {
 	}
 
 	// 투표 여부 및 투표 아이템 가져오기
-	public VotedAndVoteItemsGetResponse getVotedAndVoteItems(Member member, Long roomId) {
+	public VotedAndVoteItemsGetResponse getVotedAndVoteItems(Member member, String roomId) {
 		// 방에 대한 회원인지 확인
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 


### PR DESCRIPTION
## 개요
- close #158 

## 작업사항
### 문제 상황
현재 조회, 삭제, 변경 API들에서 사용되는 RoomId는 0부터 순차부여되는 정수로 되어있다.
이렇게 하면 유저들이 다음이나 이전 RoomId를 추측할 수 있게 되어 임의로 방에 들어갈 수 있게 된다.
따라서 RoomId 기본키 말고 임의의 String IndentityKey를 부여하여 유추할 수 없게 끔 하고자 한다.

### 해결
![image](https://github.com/user-attachments/assets/e2d6da99-d9f4-4c5a-83cd-6aa440bffadb)
![image](https://github.com/user-attachments/assets/2dbe8c85-c627-416c-94f3-f93fa6edf57a)

서비스 변경을 최소화하기 위해 별도의 identityKey를 추가하지 않고 roomId를 String으로 변경 및 room생성 시 UUID 숫자를 저장하도록 하였다.

또한 이에 맞게 모든 api에서 `Long roomId`를 `String roomId`로 변경하였다.