### PR TITLE
Feature: swagger url 설정 프로필을 통해 하도록 변경

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/BackendApplication.java
+++ b/backend/src/main/java/middle_point_search/backend/BackendApplication.java
@@ -10,8 +10,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.servers.Server;
 import jakarta.annotation.PostConstruct;
 import middle_point_search.backend.common.filter.RateLimitFilter;
 
@@ -19,7 +17,6 @@ import middle_point_search.backend.common.filter.RateLimitFilter;
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAspectJAutoProxy
-@OpenAPIDefinition(servers = {@Server(url = "/", description = "https://www.api.cotato-midpoint.site")})
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/middle_point_search/backend/common/properties/SwaggerProperties.java
+++ b/backend/src/main/java/middle_point_search/backend/common/properties/SwaggerProperties.java
@@ -1,0 +1,15 @@
+package middle_point_search.backend.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "swagger")
+public class SwaggerProperties {
+	private String url;
+}

--- a/backend/src/main/java/middle_point_search/backend/common/properties/conf/PropertyConfig.java
+++ b/backend/src/main/java/middle_point_search/backend/common/properties/conf/PropertyConfig.java
@@ -11,6 +11,7 @@ import middle_point_search.backend.common.properties.KakaoProperties;
 import middle_point_search.backend.common.properties.MarketProperties;
 import middle_point_search.backend.common.properties.RedisProperties;
 import middle_point_search.backend.common.properties.SecurityProperties;
+import middle_point_search.backend.common.properties.SwaggerProperties;
 
 // 전역적으로 사용되는 상수
 @Configuration
@@ -22,7 +23,8 @@ import middle_point_search.backend.common.properties.SecurityProperties;
 	KakaoProperties.class,
 	RedisProperties.class,
 	GoogleProperties.class,
-	EmailProperties.class
+	EmailProperties.class,
+	SwaggerProperties.class
 })
 public class PropertyConfig {
 }

--- a/backend/src/main/java/middle_point_search/backend/common/swagger/conf/SwaggerConfig.java
+++ b/backend/src/main/java/middle_point_search/backend/common/swagger/conf/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package middle_point_search.backend.common.swagger.conf;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,9 +11,16 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import middle_point_search.backend.common.properties.SwaggerProperties;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+	private final SwaggerProperties swaggerProperties;
+
 	@Bean
 	public OpenAPI openAPI() {
 
@@ -22,6 +30,7 @@ public class SwaggerConfig {
 		SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
 		return new OpenAPI()
+			.servers(List.of(new Server().url(swaggerProperties.getUrl()).description("백엔드 서버")))
 			.components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
 			.security(Arrays.asList(securityRequirement))
 			.info(apiInfo());


### PR DESCRIPTION
## 개요
- close #170 

## 작업사항
기존의 swagger에서 보낼 요청 url은 BackendApplication에서 관리하고 있었다.
이는 변경에 용이하지 않아 SwaggerConfig에 프로필을 통해 주입할 수 있도록 변경하였다.
![image](https://github.com/user-attachments/assets/f0e9c26b-230c-451f-bb38-bbcbc4d76ab0)
기존과 달리 SwaggerProperties에서 url을 가져와 설정해준다.
![image](https://github.com/user-attachments/assets/8fedba0e-ecdf-4db0-8540-7b06abd9412e)
잘 적용된 것을 볼 수 있다,