### PR TITLE
Feature: MemberRoom 테스트 코드 구현(#180)

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/common/exception/errorCode/UserErrorCode.java
+++ b/backend/src/main/java/middle_point_search/backend/common/exception/errorCode/UserErrorCode.java
@@ -27,7 +27,6 @@ public enum UserErrorCode implements ErrorCode {
 	ROOM_TYPE_UNPROCESSABLE(HttpStatus.UNPROCESSABLE_ENTITY, "R-001", "방의 타입이 일치하지 않습니다."),
 
 	//MemberRoom 관련
-	MEMBER_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "MR-001", "해당 방에 회원이 아닙니다"),
 	DUPLICATE_MEMBER_ROOM(HttpStatus.CONFLICT, "MR-002", "해당 방에 이미 존재하는 회원입니다."),
 	UNAUTHORIZED_MEMBER_ROOM(HttpStatus.FORBIDDEN, "MR-003", "해당 방의 회원이 아닙니다."),
 

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/controller/MemberRoomController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/controller/MemberRoomController.java
@@ -168,7 +168,7 @@ public class MemberRoomController {
 			),
 			@ApiResponse(
 				responseCode = "409",
-				description = "해당 방에 존재하지 않는 회원입니다.[MR-001]",
+				description = "해당 방에 존재하지 않는 회원입니다.[MR-003]",
 				content = @Content(schema = @Schema(implementation = ErrorResponse.class))
 			)
 		}

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/repository/MemberRoomRepository.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/repository/MemberRoomRepository.java
@@ -19,4 +19,6 @@ public interface MemberRoomRepository extends JpaRepository<MemberRoom, Long> {
 	void deleteByRoomIdAndMemberId(String roomId, Long memberId);
 
 	boolean existsByRoomId(String roomId);
+
+	boolean existsByRoomIdAndMemberId(String roomId, Long memberId);
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/memberRoom/service/MemberRoomService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/memberRoom/service/MemberRoomService.java
@@ -66,6 +66,16 @@ public class MemberRoomService {
 	// 회원방에서 회원 삭제, 방이 없으면 방 삭제
 	@Transactional
 	public void deleteMemberFromRoom(Long memberId, String roomId) {
+		// 방이 없으면 예외
+		if (!roomRepository.existsById(roomId)) {
+			throw CustomException.from(ROOM_NOT_FOUND);
+		}
+
+		// 방에 존재하는 회원이 아니면 예외
+		if (!memberRoomRepository.existsByRoomIdAndMemberId(roomId, memberId)) {
+			throw CustomException.from(UNAUTHORIZED_MEMBER_ROOM);
+		}
+
 		memberRoomRepository.deleteByRoomIdAndMemberId(roomId, memberId);
 
 		// 방에 멤버가 없으면 방 삭제

--- a/backend/src/test/java/middle_point_search/backend/domains/memberRoom/DeleteMemberFromRoomTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/memberRoom/DeleteMemberFromRoomTest.java
@@ -1,0 +1,153 @@
+package middle_point_search.backend.domains.memberRoom;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("방에서 회원 삭제")
+public class DeleteMemberFromRoomTest extends BaseIntegrationTest {
+	private String memberAccessToken;
+	private String memberEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		memberAccessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("방에서 회원 삭제에 성공한다.")
+	void 방에서회원삭제성공() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/member-rooms/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isOk());
+		// 방에서 회원 삭제 확인
+		assertFalse(memberRoomRepository.existsById(memberRoom.getId()));
+	}
+
+	@Test
+	@DisplayName("방에서 회원 삭제에 실패한다. - 방의 회원이 아님")
+	void 방에서회원삭제실패_방의회원이아님() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/member-rooms/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(jsonPath("$.code").value("MR-003"));
+	}
+
+	@Test
+	@DisplayName("방에서 회원 삭제에 실패한다. - 방이 존재하지 않음")
+	void 방에서회원삭제실패_방이존재하지않음() throws Exception {
+		// given
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/member-rooms/rooms/{roomId}", "roomId")
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(jsonPath("$.code").value("R-201"));
+	}
+
+	@Test
+	@DisplayName("회원 삭제시 방에 아무도 없으면 방도 삭제된다.")
+	void 회원삭제시방에아무도없으면방도삭제된다() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/member-rooms/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isOk());
+		// 방 삭제 확인
+		assertFalse(roomRepository.existsById(roomId));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/memberRoom/ExistsMemberRoomTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/memberRoom/ExistsMemberRoomTest.java
@@ -1,0 +1,97 @@
+package middle_point_search.backend.domains.memberRoom;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("회원방 존재 여부 테스트")
+public class ExistsMemberRoomTest extends BaseIntegrationTest {
+
+	private String memberAccessToken;
+	private String memberEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		memberAccessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("방에 회원이 존재하면 true를 반환한다.")
+	void 방에_회원이_존재하면_true를_반환한다() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		String roomName = "roomName";
+		Room room = roomRepository.save(Room.builder()
+			.id(roomId)
+			.name(roomName)
+			.memo("roomMemo")
+			.build());
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/member-rooms/exists/rooms/" + roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.exists").value(true));
+	}
+
+	@Test
+	@DisplayName("방에 회원이 존재하지 않으면 false를 반환한다.")
+	void 방에_회원이_존재하지_않으면_false를_반환한다() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = roomRepository.save(Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/member-rooms/exists/rooms/" + roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.exists").value(false));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/memberRoom/FindRoomsTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/memberRoom/FindRoomsTest.java
@@ -1,0 +1,143 @@
+package middle_point_search.backend.domains.memberRoom;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("회원이 속한 방들 조회")
+public class FindRoomsTest extends BaseIntegrationTest {
+
+	private String accessToken;
+	private String memberEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		accessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("회원이 속한 방들을 조회한다.")
+	void 회원이_속한_방들_조회() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		String roomName = "roomName";
+		Room room = roomRepository.save(Room.builder()
+			.id(roomId)
+			.name(roomName)
+			.memo("roomMemo")
+			.build());
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		// 방 조회
+		ResultActions resultActions = mockMvc.perform(get("/api/member-rooms")
+			.header("Authorization", "Bearer " + accessToken)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].roomId").value(roomId))
+			.andExpect(jsonPath("$.data[0].roomName").value(roomName));
+	}
+
+	@Test
+	@DisplayName("회원이 속한 방이 없으면 빈 리스트를 반환한다.")
+	void 회원이_속한_방이_없으면_빈_리스트를_반환() throws Exception {
+		// when
+		// 방 조회
+		ResultActions resultActions = mockMvc.perform(get("/api/member-rooms")
+			.header("Authorization", "Bearer " + accessToken)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isEmpty());
+	}
+
+	@Test
+	@DisplayName("회원이 속한 방이 여러개일 때 모두 조회한다.")
+	void 회원이_속한_방이_여러개일_때_모두_조회() throws Exception {
+		// given
+		// 방 생성
+		String roomId1 = "roomId1";
+		String roomName1 = "roomName1";
+		Room room1 = roomRepository.save(Room.builder()
+			.id(roomId1)
+			.name(roomName1)
+			.memo("roomMemo1")
+			.build());
+
+		String roomId2 = "roomId2";
+		String roomName2 = "roomName2";
+		Room room2 = roomRepository.save(Room.builder()
+			.id(roomId2)
+			.name(roomName2)
+			.memo("roomMemo2")
+			.build());
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room1)
+			.build());
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room2)
+			.build());
+
+		// when
+		// 방 조회
+		ResultActions resultActions = mockMvc.perform(get("/api/member-rooms")
+			.header("Authorization", "Bearer " + accessToken)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].roomId").value(roomId1))
+			.andExpect(jsonPath("$.data[0].roomName").value(roomName1))
+			.andExpect(jsonPath("$.data[1].roomId").value(roomId2))
+			.andExpect(jsonPath("$.data[1].roomName").value(roomName2));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/memberRoom/SaveMemberToRoomTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/memberRoom/SaveMemberToRoomTest.java
@@ -15,6 +15,7 @@ import middle_point_search.backend.common.BaseIntegrationTest;
 import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
 import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
 import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
 import middle_point_search.backend.domains.room.domain.Room;
 import middle_point_search.backend.domains.room.repository.RoomRepository;
@@ -23,6 +24,7 @@ import middle_point_search.backend.domains.room.repository.RoomRepository;
 public class SaveMemberToRoomTest extends BaseIntegrationTest {
 
 	private String accessToken;
+	private String memberEmail;
 
 	@Autowired
 	private MemberRoomRepository memberRoomRepository;
@@ -35,6 +37,7 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 	public void setUp() throws Exception {
 		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
 
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
 		accessToken = accessTokenAndRefreshToken.accessToken();
 	}
 
@@ -52,7 +55,7 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 		roomRepository.save(room);
 
 		// 회원 id 조회
-		Member member = memberRepository.findByEmail(NO_ADDRESS_MEMBER_EMAIL)
+		Member member = memberRepository.findByEmail(memberEmail)
 			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
 		// when
@@ -66,5 +69,55 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 
 		// 방에 회원 저장 확인
 		Assertions.assertTrue(memberRoomRepository.existsByMember_IdAndRoom_Id(member.getId(), roomId));
+	}
+
+	@Test
+	@DisplayName("방이 존재하지 않으면 R-201을 반환한다.")
+	public void 방이존재하지않으면_R_201을반환() throws Exception {
+		// given
+		String nonExistRoomId = "nonExistRoomId";
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/member-rooms/rooms/{roomId}", nonExistRoomId)
+			.header("Authorization", "Bearer " + accessToken)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(jsonPath("$.code").value("R-201"));
+	}
+
+
+	@Test
+	@DisplayName("해당 방에 이미 존재하는 회원이면 MR-002를 반환한다.")
+	public void 해당방에이미존재하는회원이면_MR_002를반환() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/member-rooms/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + accessToken)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(jsonPath("$.code").value("MR-002"));
 	}
 }

--- a/backend/src/test/java/middle_point_search/backend/domains/memberRoom/SaveMemberToRoomTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/memberRoom/SaveMemberToRoomTest.java
@@ -1,0 +1,70 @@
+package middle_point_search.backend.domains.memberRoom;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("방에 회원 저장")
+public class SaveMemberToRoomTest extends BaseIntegrationTest {
+
+	private String accessToken;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		accessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("방에 회원 저장에 성공한다.")
+	public void 방에회원저장성공() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(NO_ADDRESS_MEMBER_EMAIL)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/member-rooms/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + accessToken)
+			.accept(MediaType.APPLICATION_JSON)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk());
+
+		// 방에 회원 저장 확인
+		Assertions.assertTrue(memberRoomRepository.existsByMember_IdAndRoom_Id(member.getId(), roomId));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/memberRoom/SaveMemberToRoomTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/memberRoom/SaveMemberToRoomTest.java
@@ -34,7 +34,7 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 	private MemberRepository memberRepository;
 
 	@BeforeEach
-	public void setUp() throws Exception {
+	void setUp() throws Exception {
 		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
 
 		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
@@ -43,7 +43,7 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 
 	@Test
 	@DisplayName("방에 회원 저장에 성공한다.")
-	public void 방에회원저장성공() throws Exception {
+	void 방에회원저장성공() throws Exception {
 		// given
 		// 방 생성
 		String roomId = "roomId";
@@ -73,7 +73,7 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 
 	@Test
 	@DisplayName("방이 존재하지 않으면 R-201을 반환한다.")
-	public void 방이존재하지않으면_R_201을반환() throws Exception {
+	void 방이존재하지않으면_R_201을반환() throws Exception {
 		// given
 		String nonExistRoomId = "nonExistRoomId";
 
@@ -90,7 +90,7 @@ public class SaveMemberToRoomTest extends BaseIntegrationTest {
 
 	@Test
 	@DisplayName("해당 방에 이미 존재하는 회원이면 MR-002를 반환한다.")
-	public void 해당방에이미존재하는회원이면_MR_002를반환() throws Exception {
+	void 해당방에이미존재하는회원이면_MR_002를반환() throws Exception {
 		// given
 		// 방 생성
 		String roomId = "roomId";


### PR DESCRIPTION
## 개요
- close #180 

## 작업사항
### MemberRoom 저장 API
* 방에 회원 저장에 성공한다.
* 방이 존재하지 않으면 R-201을 반환한다.
* 해당 방에 이미 존재하는 회원이면 MR-002를 반환한다.
### 회원이 속한 방 찾기 API
* 회원이 속한 방들을 조회한다.
* 회원이 속한 방이 없으면 빈 리스트를 반환한다.
* 회원이 속한 방이 여러개일 때 모두 조회한다.
### 회원방 존재 여부 API
* 방에 회원이 존재하면 true를 반환한다.
* 방에 회원이 존재하지 않으면 false를 반환한다.
### 방에서 회원 삭제 API
* 방에서 회원 삭제에 성공한다.
* 방에서 회원 삭제에 실패한다. - 방의 회원이 아님
* 방에서 회원 삭제에 실패한다. - 방이 존재하지 않음
* 회원 삭제시 방에 아무도 없으면 방도 삭제된다.