### PR TITLE
Feature: Place 테스트 코드 구현(#182)

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/common/security/filter/jwtFilter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/middle_point_search/backend/common/security/filter/jwtFilter/JwtAuthenticationFilter.java
@@ -18,7 +18,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import middle_point_search.backend.common.exception.CustomException;
-import middle_point_search.backend.common.exception.errorCode.CommonErrorCode;
 import middle_point_search.backend.common.properties.SecurityProperties;
 
 @Slf4j
@@ -73,7 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			throw CustomException.from(REISSUE_ACCESS_TOKEN);
 		} else {
 			log.info("인증 실패");
-			throw CustomException.from(CommonErrorCode.UNAUTHORIZED);
+			throw CustomException.from(REISSUE_ACCESS_TOKEN);
 		}
 	}
 

--- a/backend/src/main/java/middle_point_search/backend/common/security/filter/jwtFilter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/middle_point_search/backend/common/security/filter/jwtFilter/JwtAuthenticationFilter.java
@@ -72,7 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			throw CustomException.from(REISSUE_ACCESS_TOKEN);
 		} else {
 			log.info("인증 실패");
-			throw CustomException.from(REISSUE_ACCESS_TOKEN);
+			throw CustomException.from(INVALID_REFRESH_TOKEN);
 		}
 	}
 

--- a/backend/src/main/java/middle_point_search/backend/common/webClient/util/WebClientUtil.java
+++ b/backend/src/main/java/middle_point_search/backend/common/webClient/util/WebClientUtil.java
@@ -99,7 +99,7 @@ public class WebClientUtil {
 				.build())
 			.retrieve()
 			.onStatus(HttpStatusCode::is4xxClientError,
-				clientResponse -> Mono.error(CustomException.from(BAD_REQUEST)))
+				clientResponse -> Mono.error(CustomException.from(API_INTERNAL_SERVER_ERROR)))
 			.onStatus(HttpStatusCode::is5xxServerError,
 				clientResponse -> Mono.error(CustomException.from(API_INTERNAL_SERVER_ERROR)))
 			.bodyToMono(response)

--- a/backend/src/main/java/middle_point_search/backend/domains/place/domain/Place.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/domain/Place.java
@@ -73,11 +73,11 @@ public class Place {
 		String googlePlaceId
 	) {
 		return new Place(
-			request.getSiDo(),
-			request.getSiGunGu(),
-			request.getRoadNameAddress(),
-			request.getAddressLat(),
-			request.getAddressLong(),
+			request.siDo(),
+			request.siGunGu(),
+			request.roadNameAddress(),
+			request.addressLat(),
+			request.addressLong(),
 			room,
 			member,
 			googlePlaceId

--- a/backend/src/main/java/middle_point_search/backend/domains/place/dto/request/SavePlaceRequest.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/dto/request/SavePlaceRequest.java
@@ -2,26 +2,12 @@ package middle_point_search.backend.domains.place.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class SavePlaceRequest {
-
-	@NotBlank(message = "siDo는 비어 있을 수 없습니다.")
-	private String siDo;
-
-	@NotBlank(message = "siGunGu는 비어 있을 수 없습니다.")
-	private String siGunGu;
-
-	@NotBlank(message = "roadNameAddress는 비어 있을 수 없습니다.")
-	private String roadNameAddress;
-
-	@NotNull(message = "addressLat는 비어 있을 수 없습니다.")
-	private Double addressLat;
-
-	@NotNull(message = "addressLong는 비어 있을 수 없습니다.")
-	private Double addressLong;
+public record SavePlaceRequest(
+	@NotBlank(message = "siDo는 비어 있을 수 없습니다.") String siDo,
+	@NotBlank(message = "siGunGu는 비어 있을 수 없습니다.") String siGunGu,
+	@NotBlank(message = "roadNameAddress는 비어 있을 수 없습니다.") String roadNameAddress,
+	@NotNull(message = "addressLat는 비어 있을 수 없습니다.") Double addressLat,
+	@NotNull(message = "addressLong는 비어 있을 수 없습니다.") Double addressLong
+) {
 }

--- a/backend/src/main/java/middle_point_search/backend/domains/place/dto/request/UpdatePlaceRequest.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/dto/request/UpdatePlaceRequest.java
@@ -2,29 +2,12 @@ package middle_point_search.backend.domains.place.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class UpdatePlaceRequest {
-
-	@NotNull(message = "placeId는 비어 있을 수 없습니다.")
-	private Long placeId;
-
-	@NotBlank(message = "siDo는 비어 있을 수 없습니다.")
-	private String siDo;
-
-	@NotBlank(message = "siGunGu는 비어 있을 수 없습니다.")
-	private String siGunGu;
-
-	@NotBlank(message = "roadNameAddress는 비어 있을 수 없습니다.")
-	private String roadNameAddress;
-
-	@NotNull(message = "addressLat는 비어 있을 수 없습니다.")
-	private Double addressLat;
-
-	@NotNull(message = "addressLong는 비어 있을 수 없습니다.")
-	private Double addressLong;
-}
+public record UpdatePlaceRequest(
+	@NotNull(message = "placeId는 비어 있을 수 없습니다.") Long placeId,
+	@NotBlank(message = "siDo는 비어 있을 수 없습니다.") String siDo,
+	@NotBlank(message = "siGunGu는 비어 있을 수 없습니다.") String siGunGu,
+	@NotBlank(message = "roadNameAddress는 비어 있을 수 없습니다.") String roadNameAddress,
+	@NotNull(message = "addressLat는 비어 있을 수 없습니다.") Double addressLat,
+	@NotNull(message = "addressLong는 비어 있을 수 없습니다.") Double addressLong
+) {}

--- a/backend/src/main/java/middle_point_search/backend/domains/place/service/PlaceService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/place/service/PlaceService.java
@@ -67,7 +67,7 @@ public class PlaceService {
 			.orElseThrow(() -> CustomException.from(ROOM_NOT_FOUND));
 
 		// 구글 placeId 조회
-		String googlePlaceId = googleService.findGooglePlaceId(request.getAddressLat(), request.getAddressLong());
+		String googlePlaceId = googleService.findGooglePlaceId(request.addressLat(), request.addressLong());
 
 		Place place = placeRepository.save(Place.from(request, room, member, googlePlaceId));
 
@@ -81,17 +81,17 @@ public class PlaceService {
 		memberRoomValidateService.validateAuthorizedMember(member.getId(), roomId);
 
 		// 구글 placeId 조회
-		String googlePlaceId = googleService.findGooglePlaceId(request.getAddressLat(), request.getAddressLong());
+		String googlePlaceId = googleService.findGooglePlaceId(request.addressLat(), request.addressLong());
 
 		placeRepository.updatePlace(
 			member.getId(),
-			request.getPlaceId(),
+			request.placeId(),
 			googlePlaceId,
-			request.getSiDo(),
-			request.getSiGunGu(),
-			request.getRoadNameAddress(),
-			request.getAddressLat(),
-			request.getAddressLong());
+			request.siDo(),
+			request.siGunGu(),
+			request.roadNameAddress(),
+			request.addressLat(),
+			request.addressLong());
 	}
 
 	// 장소 삭제

--- a/backend/src/main/resources/logback/logback-spring.xml
+++ b/backend/src/main/resources/logback/logback-spring.xml
@@ -23,6 +23,16 @@
         <logger level="DEBUG" name="org.hibernate.SQL"/>
     </springProfile>
 
+    <!--test: 콘솔에 출력-->
+    <springProfile name="test">
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger level="DEBUG" name="org.hibernate.SQL"/>
+    </springProfile>
+
     <!--dev:콘솔, 파일 둘다 출력-->
     <springProfile name="dev">
 

--- a/backend/src/test/java/middle_point_search/backend/common/BaseIntegrationTest.java
+++ b/backend/src/test/java/middle_point_search/backend/common/BaseIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,9 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
 import middle_point_search.backend.domains.member.domain.Member;
 import middle_point_search.backend.domains.member.domain.Role;
-import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
 import middle_point_search.backend.domains.member.dto.request.LoginMemberRequest;
 import middle_point_search.backend.domains.member.repository.MemberRepository;
 
@@ -25,6 +26,7 @@ import middle_point_search.backend.domains.member.repository.MemberRepository;
 @Disabled
 @AutoConfigureMockMvc
 @Transactional
+@ActiveProfiles({"test", "common"})
 public class BaseIntegrationTest {
 	@Autowired
 	protected MockMvc mockMvc;

--- a/backend/src/test/java/middle_point_search/backend/domains/place/DeletePlaceTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/place/DeletePlaceTest.java
@@ -1,0 +1,170 @@
+package middle_point_search.backend.domains.place;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.place.domain.Place;
+import middle_point_search.backend.domains.place.repository.PlaceRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("장소 삭제 테스트")
+public class DeletePlaceTest extends BaseIntegrationTest {
+
+	private String memberAccessToken;
+	private String memberEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private PlaceRepository placeRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		memberAccessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("장소 삭제에 성공한다.")
+	void 장소삭제성공() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.build();
+		roomRepository.save(room);
+
+		// 멤버 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+		// 방에 멤버 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.room(room)
+			.member(member)
+			.build());
+
+		// 장소 생성
+		Place place = Place.builder()
+			.siDo("siDo")
+			.siGunGu("siGunGu")
+			.roadNameAddress("roadNameAddress")
+			.room(room)
+			.addressLatitude(1.0)
+			.addressLongitude(1.0)
+			.member(member)
+			.googlePlaceId("googlePlaceId")
+			.build();
+		place = placeRepository.save(place);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/places/{placeId}", place.getId())
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isOk());
+
+		// 장소 삭제 확인
+		assertFalse(placeRepository.existsById(place.getId()));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 장소를 삭제하면 실패한다.")
+	void 존재하지않는장소삭제실패() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.build();
+		roomRepository.save(room);
+
+		// 멤버 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+
+		// 방에 멤버 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.room(room)
+			.member(member)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/places/{placeId}", "422")
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("P-201"));
+	}
+
+	@Test
+	@DisplayName("방에 속하지 않은 멤버가 장소를 삭제하면 실패한다.")
+	void 방에속하지않은멤버장소삭제실패() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.build();
+		roomRepository.save(room);
+
+		// 멤버 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+
+		// 장소 생성
+		Place place = Place.builder()
+			.siDo("siDo")
+			.siGunGu("siGunGu")
+			.roadNameAddress("roadNameAddress")
+			.room(room)
+			.addressLatitude(1.0)
+			.addressLongitude(1.0)
+			.member(member)
+			.googlePlaceId("googlePlaceId")
+			.build();
+		place = placeRepository.save(place);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/places/{placeId}", place.getId())
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("MR-003"));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/place/FindPlaceTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/place/FindPlaceTest.java
@@ -1,0 +1,232 @@
+package middle_point_search.backend.domains.place;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.place.domain.Place;
+import middle_point_search.backend.domains.place.repository.PlaceRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("장소 찾기 테스트")
+public class FindPlaceTest extends BaseIntegrationTest {
+
+	private String memberAccessToken;
+	private String memberEmail;
+	private String friendEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private PlaceRepository placeRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+		signupAndLoginMember(true);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		memberAccessToken = accessTokenAndRefreshToken.accessToken();
+
+		friendEmail = ADDRESS_MEMBER_EMAIL;
+	}
+
+	// 내가 저장한 장소 조회를 성공한다.
+	@Test
+	@DisplayName("내가 저장한 장소 조회를 성공한다.")
+	void 내가_저장한_장소_조회 () throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// 장소 저장
+		final String siDo = "서울특별시";
+		final String siGunGu = "강남구";
+		final String roadNameAddress = "강남대로 123";
+		final Double addressLatitude = 37.123456;
+		final Double addressLongitude = 127.123456;
+
+		placeRepository.save(Place.builder()
+			.siDo(siDo)
+			.siGunGu(siGunGu)
+			.roadNameAddress(roadNameAddress)
+			.addressLatitude(addressLatitude)
+			.addressLongitude(addressLongitude)
+			.room(room)
+			.member(member)
+			.googlePlaceId("googlePlaceId")
+			.build());
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.myLocationExistence").value(true))
+			.andExpect(jsonPath("$.data.myLocations[0].placeId").exists())
+			.andExpect(jsonPath("$.data.myLocations[0].siDo").value(siDo))
+			.andExpect(jsonPath("$.data.myLocations[0].siGunGu").value(siGunGu))
+			.andExpect(jsonPath("$.data.myLocations[0].roadNameAddress").value(roadNameAddress))
+			.andExpect(jsonPath("$.data.myLocations[0].addressLat").value(addressLatitude))
+			.andExpect(jsonPath("$.data.myLocations[0].addressLong").value(addressLongitude));
+	}
+
+	// 친구가 저장한 장소 조회를 성공한다.
+	@Test
+	@DisplayName("친구가 저장한 장소 조회를 성공한다.")
+	void 친구가_저장한_장소_조회 () throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+		Member friend = memberRepository.findByEmail(friendEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(friend)
+			.room(room)
+			.build());
+
+		// 장소 저장
+		final String siDo = "서울특별시";
+		final String siGunGu = "강남구";
+		final String roadNameAddress = "강남대로 123";
+		final Double addressLatitude = 37.123456;
+		final Double addressLongitude = 127.123456;
+
+		placeRepository.save(Place.builder()
+			.siDo(siDo)
+			.siGunGu(siGunGu)
+			.roadNameAddress(roadNameAddress)
+			.addressLatitude(addressLatitude)
+			.addressLongitude(addressLongitude)
+			.room(room)
+			.member(friend)
+			.googlePlaceId("googlePlaceId")
+			.build());
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.friendLocationExistence").value(true))
+			.andExpect(jsonPath("$.data.friendLocations[0].siDo").value(siDo))
+			.andExpect(jsonPath("$.data.friendLocations[0].siGunGu").value(siGunGu))
+			.andExpect(jsonPath("$.data.friendLocations[0].roadNameAddress").value(roadNameAddress))
+			.andExpect(jsonPath("$.data.friendLocations[0].addressLat").value(addressLatitude))
+			.andExpect(jsonPath("$.data.friendLocations[0].addressLong").value(addressLongitude));
+	}
+
+	// 내가 저장한 장소와 친구가 저장한 장소가 모두 없을 때 조회를 성공한다.
+	@Test
+	@DisplayName("내가 저장한 장소와 친구가 저장한 장소가 모두 없을 때 조회를 성공한다.")
+	void 내가_저장한_장소와_친구가_저장한_장소가_모두_없을_때_조회 () throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 멤머 버장
+		memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.myLocationExistence").value(false))
+			.andExpect(jsonPath("$.data.friendLocationExistence").value(false));
+	}
+
+	@Test
+	@DisplayName("방에 속하지 않은 회원이 장소 조회를 실패한다.")
+	void 방에_속하지_않은_회원이_장소_조회 () throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.accept(MediaType.APPLICATION_JSON));
+
+		// then
+		resultActions
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("MR-003"));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/place/SavePlaceTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/place/SavePlaceTest.java
@@ -21,7 +21,6 @@ import middle_point_search.backend.domains.member.repository.MemberRepository;
 import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
 import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
 import middle_point_search.backend.domains.place.dto.request.SavePlaceRequest;
-import middle_point_search.backend.domains.place.repository.PlaceRepository;
 import middle_point_search.backend.domains.room.domain.Room;
 import middle_point_search.backend.domains.room.repository.RoomRepository;
 
@@ -37,8 +36,6 @@ public class SavePlaceTest extends BaseIntegrationTest {
 	private RoomRepository roomRepository;
 	@Autowired
 	private MemberRepository memberRepository;
-	@Autowired
-	private PlaceRepository placeRepository;
 
 	@BeforeEach
 	void setUp() throws Exception {

--- a/backend/src/test/java/middle_point_search/backend/domains/place/SavePlaceTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/place/SavePlaceTest.java
@@ -1,0 +1,258 @@
+package middle_point_search.backend.domains.place;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.place.dto.request.SavePlaceRequest;
+import middle_point_search.backend.domains.place.repository.PlaceRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("장소 저장 테스트")
+public class SavePlaceTest extends BaseIntegrationTest {
+
+	private String memberAccessToken;
+	private String memberEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private PlaceRepository placeRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		memberAccessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("장소 저장에 성공한다.")
+	void 장소저장성공() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		// 장소 저장
+		SavePlaceRequest savePlaceRequest = new SavePlaceRequest(
+			"서울특별시",
+			"강남구",
+			"강남대로 123",
+			37.123456,
+			127.123456
+		);
+
+		ResultActions resultActions = mockMvc.perform(post("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(savePlaceRequest)));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.placeId").isNotEmpty());
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideSavePlaceRequests")
+	@DisplayName("장소 저장에 실패한다.")
+	void 장소저장실패(SavePlaceRequest savePlaceRequest) throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(savePlaceRequest)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("C-202"));
+	}
+
+	private static Stream<SavePlaceRequest> provideSavePlaceRequests() {
+		return Stream.of(
+			// 시도가 없는 경우
+			new SavePlaceRequest(
+				"",
+				"강남구",
+				"강남대로 123",
+				37.123456,
+				127.123456
+			),
+			// 시군구가 없는 경우
+			new SavePlaceRequest(
+				"서울특별시",
+				"",
+				"강남대로 123",
+				37.123456,
+				127.123456
+			),
+			// 상세주소가 없는 경우
+			new SavePlaceRequest(
+				"서울특별시",
+				"강남구",
+				"",
+				37.123456,
+				127.123456
+			),
+			// 위도가 없는 경우
+			new SavePlaceRequest(
+				"서울특별시",
+				"강남구",
+				"강남대로 123",
+				null,
+				127.123456
+			),
+			// 경도가 없는 경우
+			new SavePlaceRequest(
+				"서울특별시",
+				"강남구",
+				"강남대로 123",
+				37.123456,
+				null
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("회원이 방에 속해있지 않으면 장소 저장에 실패한다.")
+	void 회원이_방에_속해있지_않으면_장소저장실패() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// when
+		// 장소 저장
+		SavePlaceRequest savePlaceRequest = new SavePlaceRequest(
+			"서울특별시",
+			"강남구",
+			"강남대로 123",
+			37.123456,
+			127.123456
+		);
+
+		ResultActions resultActions = mockMvc.perform(post("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(savePlaceRequest)));
+
+		// then
+		resultActions.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("MR-003"));
+	}
+
+	@Test
+	@DisplayName("API 호출시 문제가 발생하면 장소 저장에 실패한다.")
+	void API호출시_문제가_발생하면_장소저장실패() throws Exception {
+		// given
+		// 방 생성
+		String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// when
+		// 장소 저장
+		SavePlaceRequest savePlaceRequest = new SavePlaceRequest(
+			"서울특별시",
+			"강남구",
+			"강남대로 123",
+			100.123456, // 잘못된 위도
+			127.123456 // 잘못된 경도
+		);
+
+		ResultActions resultActions = mockMvc.perform(post("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(savePlaceRequest)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("S-001"));
+	}
+}

--- a/backend/src/test/java/middle_point_search/backend/domains/place/UpdatePlaceTest.java
+++ b/backend/src/test/java/middle_point_search/backend/domains/place/UpdatePlaceTest.java
@@ -1,0 +1,302 @@
+package middle_point_search.backend.domains.place;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import jakarta.persistence.EntityManager;
+import middle_point_search.backend.common.BaseIntegrationTest;
+import middle_point_search.backend.common.dto.AccessTokenAndRefreshToken;
+import middle_point_search.backend.domains.member.domain.Member;
+import middle_point_search.backend.domains.member.repository.MemberRepository;
+import middle_point_search.backend.domains.memberRoom.domain.MemberRoom;
+import middle_point_search.backend.domains.memberRoom.repository.MemberRoomRepository;
+import middle_point_search.backend.domains.place.domain.Place;
+import middle_point_search.backend.domains.place.dto.request.UpdatePlaceRequest;
+import middle_point_search.backend.domains.place.repository.PlaceRepository;
+import middle_point_search.backend.domains.room.domain.Room;
+import middle_point_search.backend.domains.room.repository.RoomRepository;
+
+@DisplayName("장소 수정 테스트")
+public class UpdatePlaceTest extends BaseIntegrationTest {
+
+	private String memberAccessToken;
+	private String memberEmail;
+
+	@Autowired
+	private MemberRoomRepository memberRoomRepository;
+	@Autowired
+	private RoomRepository roomRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private PlaceRepository placeRepository;
+	@Autowired
+	private EntityManager entityManager;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		AccessTokenAndRefreshToken accessTokenAndRefreshToken = signupAndLoginMember(false);
+
+		memberEmail = NO_ADDRESS_MEMBER_EMAIL;
+		memberAccessToken = accessTokenAndRefreshToken.accessToken();
+	}
+
+	@Test
+	@DisplayName("장소 수정에 성공한다.")
+	void 장소수정성공() throws Exception {
+		// given
+		// 방 생성
+		final String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// 장소 저장
+		Place place = placeRepository.save(Place.builder()
+			.siDo("siDo")
+			.siGunGu("siGunGu")
+			.roadNameAddress("roadNameAddress")
+			.addressLatitude(1.0)
+			.addressLongitude(1.0)
+			.member(member)
+			.room(room)
+			.googlePlaceId("googlePlaceId")
+			.build());
+
+		// when
+		// 장소 수정
+		final String updateSiDo = "서울특별시";
+		final String updateSiGunGu = "강남구";
+		final String updateRoadNameAddress = "강남대로 123";
+		final Double updateAddressLat = 37.123456;
+		final Double updateAddressLong = 127.123456;
+
+		UpdatePlaceRequest updatePlaceRequest = new UpdatePlaceRequest(
+			place.getId(),
+			updateSiDo,
+			updateSiGunGu,
+			updateRoadNameAddress,
+			updateAddressLat,
+			updateAddressLong
+		);
+
+		ResultActions resultActions = mockMvc.perform(patch("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updatePlaceRequest)));
+
+		// then
+		resultActions
+			.andExpect(status().isOk());
+
+		// Place 변경은 JPQL을 사용하므로 영속성 컨텍스트에 반영되지 않아, 기존 place는 영속성 컨텍스트에 제외
+		entityManager.detach(place);
+		Place updatedPlace = placeRepository.findById(place.getId()).orElseThrow();
+		assertEquals(updatedPlace.getSiDo(), updateSiDo);
+		assertEquals(updatedPlace.getSiGunGu(), updateSiGunGu);
+		assertEquals(updatedPlace.getRoadNameAddress(), updateRoadNameAddress);
+		assertEquals(updatedPlace.getAddressLatitude(), updateAddressLat);
+		assertEquals(updatedPlace.getAddressLongitude(), updateAddressLong);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideUpdatePlaceRequests")
+	@DisplayName("장소 수정에 실패한다.")
+	void 장소수정실패(UpdatePlaceRequestDTO updatePlaceRequestDto) throws Exception {
+		// given
+		// 방 생성
+		final String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 방에 회원 저장
+		MemberRoom memberRoom = memberRoomRepository.save(MemberRoom.builder()
+			.member(member)
+			.room(room)
+			.build());
+
+		// 장소 저장
+		Place place = placeRepository.save(Place.builder()
+			.siDo("siDo")
+			.siGunGu("siGunGu")
+			.roadNameAddress("roadNameAddress")
+			.addressLatitude(1.0)
+			.addressLongitude(1.0)
+			.member(member)
+			.room(room)
+			.googlePlaceId("googlePlaceId")
+			.build());
+
+		// 장소 수정 Request 생성
+		UpdatePlaceRequest updatePlaceRequest = new UpdatePlaceRequest(
+			place.getId(),
+			updatePlaceRequestDto.siDo,
+			updatePlaceRequestDto.siGunGu,
+			updatePlaceRequestDto.roadNameAddress,
+			updatePlaceRequestDto.addressLatitude,
+			updatePlaceRequestDto.addressLongitude
+		);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(patch("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updatePlaceRequest)));
+
+		// then
+		resultActions
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("C-202"));
+	}
+
+	private static class UpdatePlaceRequestDTO {
+		private final String siDo;
+		private final String siGunGu;
+		private final String roadNameAddress;
+		private final Double addressLatitude;
+		private final Double addressLongitude;
+
+		public UpdatePlaceRequestDTO(String siDo, String siGunGu, String roadNameAddress, Double addressLatitude,
+			Double addressLongitude) {
+			this.siDo = siDo;
+			this.siGunGu = siGunGu;
+			this.roadNameAddress = roadNameAddress;
+			this.addressLatitude = addressLatitude;
+			this.addressLongitude = addressLongitude;
+		}
+	}
+
+	private static Stream<UpdatePlaceRequestDTO> provideUpdatePlaceRequests() {
+		return Stream.of(
+			// 시도가 없는 경우
+			new UpdatePlaceRequestDTO(
+				"",
+				"강남구",
+				"강남대로 123",
+				37.123456,
+				127.123456
+			),
+			// 시군구가 없는 경우
+			new UpdatePlaceRequestDTO(
+				"서울특별시",
+				"",
+				"강남대로 123",
+				37.123456,
+				127.123456
+			),
+			// 상세주소가 없는 경우
+			new UpdatePlaceRequestDTO(
+				"서울특별시",
+				"강남구",
+				"",
+				37.123456,
+				127.123456
+			),
+			// 위도가 없는 경우
+			new UpdatePlaceRequestDTO(
+				"서울특별시",
+				"강남구",
+				"강남대로 123",
+				null,
+				127.123456
+			),
+			// 경도가 없는 경우
+			new UpdatePlaceRequestDTO(
+				"서울특별시",
+				"강남구",
+				"강남대로 123",
+				37.123456,
+				null
+			)
+		);
+	}
+
+	@Test
+	@DisplayName("방에 속해있지 않으면 장소 수정에 실패한다.")
+	void 방에_속해있지_않으면_장소수정실패() throws Exception {
+		// given
+		// 방 생성
+		final String roomId = "roomId";
+		Room room = Room.builder()
+			.id(roomId)
+			.name("roomName")
+			.memo("roomMemo")
+			.build();
+		roomRepository.save(room);
+
+		// 회원 id 조회
+		Member member = memberRepository.findByEmail(memberEmail)
+			.orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+		// 장소 저장
+		Place place = placeRepository.save(Place.builder()
+			.siDo("siDo")
+			.siGunGu("siGunGu")
+			.roadNameAddress("roadNameAddress")
+			.addressLatitude(1.0)
+			.addressLongitude(1.0)
+			.member(member)
+			.room(room)
+			.googlePlaceId("googlePlaceId")
+			.build());
+
+		// when
+		// 방에 속해있지 않은 회원으로 장소 수정
+		final String updateSiDo = "서울특별시";
+		final String updateSiGunGu = "강남구";
+		final String updateRoadNameAddress = "강남대로 123";
+		final Double updateAddressLat = 37.123456;
+		final Double updateAddressLong = 127.123456;
+
+		UpdatePlaceRequest updatePlaceRequest = new UpdatePlaceRequest(
+			place.getId(),
+			updateSiDo,
+			updateSiGunGu,
+			updateRoadNameAddress,
+			updateAddressLat,
+			updateAddressLong
+		);
+
+		ResultActions resultActions = mockMvc.perform(patch("/api/places/rooms/{roomId}", roomId)
+			.header("Authorization", "Bearer " + memberAccessToken)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(updatePlaceRequest)));
+
+		// then
+		resultActions
+			.andExpect(jsonPath("$.code").value("C-203"));
+	}
+}


### PR DESCRIPTION
## 개요
- close #182

## 작업사항
### 장소 저장하기
* 장소가 정상 저장된다.
* 장소 요청 데이터의 형식이 맞지 않으면 에러를 반환한다.
* 회원이 방에 속해있지 않으면 에러를 리턴한다.
* API 호출 시 문제가 발생하면 API 에러를 리턴한다.
### 장소 변경하기
* 장소가 정상적으로 변경된다.
* 회원이 방에 속해있지 않으면 에러를 리턴한다.
### 장소 조회하기
* 내가 저장한 장소들이 정상적으로 조회된다.
* 친구들이 저장한 장소들이 정상적으로 조회된다.
* 내가 저장한 장소들과 친구들이 저장한 장소들이 정상적으로 조회된다.
* 내가 저장한 장소, 친구가 저장한 장소가 없으면 false가 리턴된다.
* 회원이 방에 속해있지 않으면 에러를 리턴한다.
### 장소 삭제하기
* 장소가 삭제된다.
* 회원이 방에 속해있지 않으면 에러를 리턴한다.
* 장소Id에 해당하는 장소가 없으면 에러를 리턴한다.
