### PR TITLE
Feature/143 implement redis cache

### DIFF
--- a/backend/src/main/java/middle_point_search/backend/common/dto/PageResponse.java
+++ b/backend/src/main/java/middle_point_search/backend/common/dto/PageResponse.java
@@ -1,0 +1,38 @@
+package middle_point_search.backend.common.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PageResponse<T> {
+	private List<T> content;
+	private int currentPage;
+	private int totalPages;
+	private long totalItems;
+
+
+	private PageResponse(List<T> content, int currentPage, int totalPages, long totalElements) {
+		this.content = content;
+		this.currentPage = currentPage;
+		this.totalPages = totalPages;
+		this.totalItems = totalElements;
+	}
+
+	public static <T> PageResponse<T> from(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getTotalPages(),
+			page.getTotalElements()
+		);
+	}
+}

--- a/backend/src/main/java/middle_point_search/backend/common/redis/RedisCacheConfig.java
+++ b/backend/src/main/java/middle_point_search/backend/common/redis/RedisCacheConfig.java
@@ -1,0 +1,45 @@
+package middle_point_search.backend.common.redis;
+
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+public class RedisCacheConfig {
+
+	// 기본 캐시 전략
+	@Bean
+	public RedisCacheConfiguration redisCacheConfiguration() {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofMinutes(1)) // TTL 설정
+			.disableCachingNullValues() // null 값 캐싱 방지
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+				new GenericJackson2JsonRedisSerializer(new ObjectMapper()) // Custom ObjectMapper 사용
+			));
+	}
+
+	// 커스텀 캐시 전략
+	@Bean
+	public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+		return (builder) -> builder
+			.withCacheConfiguration("dayTermCache",
+				RedisCacheConfiguration.defaultCacheConfig()
+					.entryTtl(Duration.ofDays(1)) // cache1에 TTL 1일
+					.serializeKeysWith(
+						RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+					.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+						new GenericJackson2JsonRedisSerializer())));
+	}
+}
+

--- a/backend/src/main/java/middle_point_search/backend/domains/recommendPlace/controller/RecommendPlaceController.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/recommendPlace/controller/RecommendPlaceController.java
@@ -1,7 +1,6 @@
 package middle_point_search.backend.domains.recommendPlace.controller;
 
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -18,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import middle_point_search.backend.common.dto.DataResponse;
 import middle_point_search.backend.common.dto.ErrorResponse;
+import middle_point_search.backend.common.dto.PageResponse;
 import middle_point_search.backend.domains.recommendPlace.dto.request.RecommendPlacesFindRequest;
 import middle_point_search.backend.domains.recommendPlace.dto.response.FindRecommendPlacesResponse;
 import middle_point_search.backend.domains.recommendPlace.service.RecommendPlaceService;
@@ -66,10 +66,10 @@ public class RecommendPlaceController {
 			)
 		}
 	)
-	public ResponseEntity<DataResponse<Page<FindRecommendPlacesResponse>>> findRecommendPlaces(
+	public ResponseEntity<DataResponse<PageResponse<FindRecommendPlacesResponse>>> findRecommendPlaces(
 		@Valid @ModelAttribute @ParameterObject RecommendPlacesFindRequest request
 	) {
-		Page<FindRecommendPlacesResponse> recommendPlaces = recommendPlaceService.findRecommendPlaces(request);
+		PageResponse<FindRecommendPlacesResponse> recommendPlaces = recommendPlaceService.findRecommendPlaces(request);
 
 		return ResponseEntity.ok(DataResponse.from(recommendPlaces));
 	}

--- a/backend/src/main/java/middle_point_search/backend/domains/recommendPlace/dto/response/FindRecommendPlacesResponse.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/recommendPlace/dto/response/FindRecommendPlacesResponse.java
@@ -3,23 +3,25 @@ package middle_point_search.backend.domains.recommendPlace.dto.response;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import middle_point_search.backend.domains.market.domain.PlaceStandard;
 import middle_point_search.backend.domains.recommendPlace.dto.response.KakaoSearchResponse.Document;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FindRecommendPlacesResponse implements Comparable<FindRecommendPlacesResponse> {
 
-	private final String name;
-	private final String siDo;
-	private final String siGunGu;
-	private final String roadNameAddress;
-	private final Double addressLat;
-	private final Double addressLong;
-	private final String phoneNumber;
-	private final String placeUrl;
-	private final PlaceStandard placeStandard;
-	private final String distance;
+	private String name;
+	private String siDo;
+	private String siGunGu;
+	private String roadNameAddress;
+	private Double addressLat;
+	private Double addressLong;
+	private String phoneNumber;
+	private String placeUrl;
+	private PlaceStandard placeStandard;
+	private String distance;
 
 	public static FindRecommendPlacesResponse from(Document document, PlaceStandard placeStandard) {
 

--- a/backend/src/main/java/middle_point_search/backend/domains/recommendPlace/service/RecommendPlaceService.java
+++ b/backend/src/main/java/middle_point_search/backend/domains/recommendPlace/service/RecommendPlaceService.java
@@ -5,7 +5,7 @@ import static java.nio.charset.StandardCharsets.*;
 import java.net.URLEncoder;
 import java.util.Collections;
 
-import org.springframework.data.domain.Page;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +16,7 @@ import org.springframework.util.MultiValueMap;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import middle_point_search.backend.common.dto.PageResponse;
 import middle_point_search.backend.common.exception.CustomException;
 import middle_point_search.backend.common.exception.errorCode.CommonErrorCode;
 import middle_point_search.backend.common.properties.KakaoProperties;
@@ -23,9 +24,9 @@ import middle_point_search.backend.common.webClient.util.WebClientUtil;
 import middle_point_search.backend.domains.market.domain.PlaceStandard;
 import middle_point_search.backend.domains.recommendPlace.dto.KakaoRequestDTO;
 import middle_point_search.backend.domains.recommendPlace.dto.request.RecommendPlacesFindRequest;
+import middle_point_search.backend.domains.recommendPlace.dto.response.FindRecommendPlacesResponse;
 import middle_point_search.backend.domains.recommendPlace.dto.response.KakaoSearchResponse;
 import middle_point_search.backend.domains.recommendPlace.dto.response.RecommendPlacesDto;
-import middle_point_search.backend.domains.recommendPlace.dto.response.FindRecommendPlacesResponse;
 
 @Slf4j
 @Service
@@ -38,7 +39,11 @@ public class RecommendPlaceService {
 	private final WebClientUtil webClientUtil;
 
 	// 키워드로 주위 장소 조회
-	public Page<FindRecommendPlacesResponse> findRecommendPlaces(RecommendPlacesFindRequest request) {
+	@Cacheable(
+		cacheNames = "dayTermCache",
+		key = "'recommend-places:log:' + #request.addressLong + ':lat:' + #request.addressLat +':place-standard:' + #request.placeStandard"
+	)
+	public PageResponse<FindRecommendPlacesResponse> findRecommendPlaces(RecommendPlacesFindRequest request) {
 		String x = request.getAddressLong().toString();
 		String y = request.getAddressLat().toString();
 		int page = request.getPage();
@@ -49,10 +54,10 @@ public class RecommendPlaceService {
 
 		RecommendPlacesDto response = checkPlaceStandardAndGetResponse(request, kakaoRequestDTO);
 
-		return new PageImpl<>(
+		return PageResponse.from(new PageImpl<>(
 			response.getRecommendPlaces(),
 			pageable,
-			response.getPageableCount());
+			response.getPageableCount()));
 	}
 
 	//PlaceStandard에 따라 KakaoSearchResponse를 가져오는 메서드


### PR DESCRIPTION
## 개요
- close #143 

## 작업사항

### 추천 장소 cache 구현
- 추천 장소는 외부 API를 호출하여 비용이 크고, 사람들의 장소가 다 입력됐을 경우 잘 변경되지 않는다. 따라서 캐시를 도입했다.
![image](https://github.com/user-attachments/assets/5cd460d7-bec1-4988-8f07-352a25bbbfd3)
![image](https://github.com/user-attachments/assets/afffbeb9-1cb7-4012-a538-bc299233c92b)
캐시는 커스텀으로 캐시기간이 1일인 캐시설정을 만들어 사용했다.
### PageResponse 구현
Page는 인터페이스라 Jackson라이브러리가 직렬화하지 못해 에러가 발생헀다.
또한 기존까지 응답에 Page가 있을 때도 경고로그가 계속 나타났다.

이를 해결하기 위해 PageResponse객체를 따로 만들어반환하도록 변경했다.